### PR TITLE
bootstrap: add support for callbacks

### DIFF
--- a/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
+++ b/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
@@ -16,6 +16,15 @@ Class {
 	#category : #'Powerlang-Core-Building'
 }
 
+{ #category : #accessing }
+ImageSegmentWriter class >> behaviorOffset [
+	"
+		The offset at which the behavior is from the oop (negated)
+	"
+
+	^ -4
+]
+
 { #category : #'class initialization' }
 ImageSegmentWriter class >> initialize [
 	WordSize := 8

--- a/bootstrap/src/Powerlang-Core/JITAssembler64.class.st
+++ b/bootstrap/src/Powerlang-Core/JITAssembler64.class.st
@@ -743,6 +743,19 @@ JITAssembler64 >> loadLargeX1withAindirect [
 ]
 
 { #category : #loading }
+JITAssembler64 >> loadLongMwithIPoffset: anInteger [
+	| instsize |
+	#dontOptimize.
+	instsize := 6.
+	pointer
+		reset;
+		length: 32;
+		base: self regIP;
+		displacement: anInteger - instsize.
+	self assemble: 'mov' with: self regM e with: pointer
+]
+
+{ #category : #loading }
 JITAssembler64 >> loadLongRWithRAtOffsetA [
 	pointer
 		reset;
@@ -1674,6 +1687,11 @@ JITAssembler64 >> regFalse [
 { #category : #private }
 JITAssembler64 >> regG [
 	^r15
+]
+
+{ #category : #private }
+JITAssembler64 >> regIP [
+	^ rip
 ]
 
 { #category : #private }

--- a/bootstrap/src/Powerlang-Core/SCallbackMethod.class.st
+++ b/bootstrap/src/Powerlang-Core/SCallbackMethod.class.st
@@ -9,6 +9,15 @@ Class {
 	#category : #'Powerlang-Core-SCompiler'
 }
 
+{ #category : #'as yet unclassified' }
+SCallbackMethod class >> behaviorNativeCodeSlot [
+	"callback methods have a special machine code. Its bytes are of
+	class ByteArray, but the behavior of this ByteArray is special:
+	it has an extra slot that allows to find the native code object
+	corresponding to this callback"
+	^4
+]
+
 { #category : #accessing }
 SCallbackMethod >> descriptor [
 	^descriptor

--- a/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
+++ b/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
@@ -251,18 +251,19 @@ SExpressionNativizer >> emitBlockPrologue: anSBlock [
 SExpressionNativizer >> emitCallbackEpilogue [
 	assembler restoreCallerFrame.
 	environment abi
-		restoreContextUsing: assembler popping: method argumentCount
+		restoreContext: method descriptor with: assembler
 ]
 
 { #category : #services }
 SExpressionNativizer >> emitCallbackPrologue [
 	| retaddr |
 	environment abi emitEntrypoint: method descriptor with: assembler.
-	retaddr := assembler dummyPointer.
+	retaddr := 0.
 	assembler
-		pushSmallInteger: retaddr;
+		pushImmediate: retaddr;
 		xorFPwithFP;
-		loadMwithImmediate: assembler dummyPointer;
+		loadLongMwithIPoffset: 0 - assembler currentAddress + ImageSegmentWriter behaviorOffset;
+		loadMwithMindex: SCallbackMethod behaviorNativeCodeSlot;
 		addLiteral: assembler lastEmittedPointer;
 		loadGwithLiteral: environment globals;
 		loadNilWithLiteral: nil;

--- a/bootstrap/src/Powerlang-Core/SmalltalkBootstrapper.class.st
+++ b/bootstrap/src/Powerlang-Core/SmalltalkBootstrapper.class.st
@@ -819,6 +819,22 @@ SmalltalkBootstrapper >> newBytesFrom: aByteObject [
 ]
 
 { #category : #initialization }
+SmalltalkBootstrapper >> newCallback: aNativeCode bytesFrom: aByteArray [
+	| code original behavior class |
+	code := self newBytesFrom: aByteArray.
+	original := code behavior.
+	behavior := self newSlots: 'CallbackBehavior'.
+	class := original slotNamed: 'class'.
+	behavior
+		slotNamed: 'class' put: class;
+		methods: original methods;
+		next: nilObj;
+		nativeCode: aNativeCode.
+	code behavior: behavior.
+	^ code
+]
+
+{ #category : #initialization }
 SmalltalkBootstrapper >> newClassVarDictionary: anArray [
 	| dict |
 	dict := self newDictionary.
@@ -1144,10 +1160,13 @@ SmalltalkBootstrapper >> transferLiteralDeep: anObject [
 
 { #category : #initialization }
 SmalltalkBootstrapper >> transferMethod: anSCompiledMethod in: species [
-	| size transferred astcodes selector format |
-	identityMap at: anSCompiledMethod ifPresent: [ :m | self ASSERT: false ].
+	| size classname transferred astcodes selector format |
+	identityMap
+		at: anSCompiledMethod
+		ifPresent: [ :m | self ASSERT: false ].
 	size := anSCompiledMethod size.
-	transferred := self newSlots: 'CompiledMethod' sized: size.
+	classname := anSCompiledMethod isCallback ifTrue: ['CallbackMethod'] ifFalse: [ 'CompiledMethod' ].
+	transferred := self newSlots: classname sized: size.
 	identityMap at: anSCompiledMethod put: transferred.
 	astcodes := self transferLiteralDeep: anSCompiledMethod astcodes.
 	selector := self newSymbol: anSCompiledMethod selector.
@@ -1164,10 +1183,13 @@ SmalltalkBootstrapper >> transferMethod: anSCompiledMethod in: species [
 
 { #category : #initialization }
 SmalltalkBootstrapper >> transferNativeCode: aNativeCode of: compiledCode [
-	| size transferred code slot |
+	| size transferred code slot callback |
 	size := aNativeCode size.
 	transferred := self newSlots: 'NativeCode' sized: size.
-	code := self newBytesFrom: aNativeCode code.
+	callback := compiledCode classname = #CallbackMethod.
+	code := callback
+		ifTrue: [ self newCallback: transferred bytesFrom: aNativeCode code ]
+		ifFalse: [ self newBytesFrom: aNativeCode code ].
 	transferred
 		machineCode: code;
 		compiledCode: compiledCode.

--- a/bootstrap/src/Powerlang-Core/SysVX64ABI.class.st
+++ b/bootstrap/src/Powerlang-Core/SysVX64ABI.class.st
@@ -6,35 +6,42 @@ Class {
 
 { #category : #'as yet unclassified' }
 SysVX64ABI >> emitEntrypoint: anFFIDescriptor with: anAssembler [
-	anAssembler saveCallerFrame.
-	self storeArgumentsInStack: anFFIDescriptor with: anAssembler.
-	anAssembler
-		pushG;
+	anAssembler saveCallerFrame;
+			pushG;
 		pushNil;
-
 		pushTrue;
-		pushFalse;		pushM;
-		loadRwithArgPointer;
-		convertRtoSmallInteger;
-		pushR
+		pushFalse;
+		pushM.
+	self storeArgumentsInStack: anFFIDescriptor with: anAssembler.
+	
 ]
 
 { #category : #'as yet unclassified' }
-SysVX64ABI >> restoreContextUsing: anAssembler popping: anInteger [
+SysVX64ABI >> popRetaddrAndArgs: anFFIDescriptor with: anAssembler [
 	anAssembler
-		restoreCallerFrame;
 		popA;
+		popA;
+		popA
+]
+
+{ #category : #'as yet unclassified' }
+SysVX64ABI >> restoreContext: anFFIDescriptor with: anAssembler [
+	self popRetaddrAndArgs: anFFIDescriptor with: anAssembler.
+	anAssembler
 		popM;
 		popFalse;
 		popTrue;
 		popNil;
 		popG;
-		restoreCallerFrame;
+		popFP;
 		return
 ]
 
 { #category : #'as yet unclassified' }
 SysVX64ABI >> storeArgumentsInStack: anFFIDescriptor with: anAssembler [
-	anAssembler
-		pushS
+
+	anAssembler pushS;
+		loadRwithArgPointer;
+		convertRtoSmallInteger;
+		pushR
 ]


### PR DESCRIPTION
now callback methods are correctly transferred as instances of CallbackMethod and not CompiledMethod. We modify the behavior of their machine code to have an extra slot, which points to the callback native code object. The entrypoint of the method fetches the special behavior through RIP-relative addressing and then loads the M register from that behavior. This saves us from having a pointer to (NativeCode) objects encoded in machine code