### PR TITLE
Jp/wip/image segment header

### DIFF
--- a/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
+++ b/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
@@ -164,10 +164,12 @@ ImageSegmentWriter >> write [
 		writeObjects
 ]
 
-{ #category : #accessing }
+{ #category : #'own services' }
 ImageSegmentWriter >> writeHeader [
 	"See ImageSegment.h for structure of a segment header"
-	stream uint64le: base; uint64le: size.
+	| reserved |
+	reserved := (space reservedLimit value - space base value) * 2.
+	stream uint64le: base; uint64le: size; uint64le: reserved.
 	self writeReferenceTo: module
 ]
 

--- a/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
+++ b/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
@@ -42,7 +42,7 @@ ImageSegmentWriter class >> objectsOffset [
 		The offset at which header terminates and objects are stored.
 		See ImageSegment.h for structure of a segment header
 	"
-	^32
+	^40
 ]
 
 { #category : #accessing }

--- a/launcher/ImageSegment.cpp
+++ b/launcher/ImageSegment.cpp
@@ -34,7 +34,7 @@ ImageSegment::load(std::istream* data)
 
     data->read(reinterpret_cast<char*>(&header), sizeof(header));
 
-    ImageSegment* segment = ImageSegment::alloc(header.baseAddress, header.size);
+    ImageSegment* segment = ImageSegment::alloc(header.baseAddress, header.reservedSize);
 
     data->seekg(0, data->beg);
     data->read(reinterpret_cast<char*>(segment), header.size);

--- a/launcher/ImageSegment.h
+++ b/launcher/ImageSegment.h
@@ -35,14 +35,18 @@ typedef struct _ImageSegmentHeader
      */
     uint64_t size;
     /**
+     * Amount of memory to be reserved when loading the segment
+     */
+    uint64_t reservedSize;
+    /**
      * A reference to Module instance describing this image segment
      */
     HeapObject* module;
 
 } ImageSegmentHeader;
 
-static_assert(sizeof(ImageSegmentHeader) == 32 /*bytes*/,
-              "segment_header size not 32bytes");
+static_assert(sizeof(ImageSegmentHeader) == 40 /*bytes*/,
+              "segment_header size not 40 bytes");
 
 class ImageSegment
 {

--- a/launcher/Windows/Memory.cpp
+++ b/launcher/Windows/Memory.cpp
@@ -4,6 +4,6 @@ uintptr_t AllocateMemory(uintptr_t base, uintptr_t size)
 {
     return reinterpret_cast<uintptr_t>(VirtualAlloc((void*)base,
                      pagealign(size), 
-                     MEM_COMMIT,
-                     PAGE_READWRITE));
+                     MEM_COMMIT | MEM_RESERVE,
+                     PAGE_EXECUTE_READWRITE));
 }


### PR DESCRIPTION
Add a new `reservedSize` field to ImageSegmentHeader. This allows the allocator to create new objects in the free buffer at the end of the image segment.