### PR TITLE
Port to Smalltalk/X 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Not that this looks like much at the moment, which bring us to:
 
 # Development
 
+## ...in Pharo
+
 To open Powerlang Pharo development image:
 
 ```
@@ -91,6 +93,11 @@ cd bootstrap
 ```
 
 All Powerlang code is in packages named `Powerlang-*`. Have fun!
+
+## ...in Smalltalk/X
+
+Please refer to [README_STX.md](README_STX.md) for instructions
+how to load Powerlang into [Smalltalk/X jv-branch](https://swing.fit.cvut.cz/projects/stx-jv)
 
 # Building launcher for Windows
 

--- a/README_STX.md
+++ b/README_STX.md
@@ -1,0 +1,69 @@
+# Developing Powerlang in Smalltalk/X
+
+**Disclaimer**: Support for using Smalltalk/X as a development system for Powerlang
+is an experimental work. Pharo is still the main development environment - changes
+to bootstrap must work in Pharo but nobody's obliged to ensure they also work in Smalltalk/X.
+This may or may not change in the (far) future.
+
+Smalltalk/X support is mainly a courtesy to those who prefer Smalltalk/X environment over
+Pharo (that is, @janvrany) and to allow experimentation with [libgdbs][4]
+
+## Prerequisites
+
+1.  Get [Smalltalk/X jv-branch][1]. Pre-build "toy" binaries for Linux
+    can be found at [https://swing.fit.cvut.cz/download/smalltalkx/devel][2]:
+
+        wget https://swing.fit.cvut.cz/download/smalltalkx/devel/YYYY-MM-DD_NNN/smalltalkx-jv-branch-8.0.99_buildNNN_x86_64-pc-linux-gnu.tar.bz2
+        tar xf smalltalkx-jv-branch-8.0.99_buildNNN_x86_64-pc-linux-gnu.tar.bz2
+        rm smalltalkx-jv-branch-8.0.99_buildNNN_x86_64-pc-linux-gnu.tar.bz2
+
+    Alternatively, you may want to build Smalltalk/X from sources, see
+    [build instructions][3]. This is actually *preferred way* to work with
+    Smalltalk/X.
+
+2.  Download an install Smalltalk/X port of RING2:
+
+        mkdir -p ~/SmalltalkXProjects/stx/goodies
+        hg clone https://swing.fit.cvut.cz/hg/stx-goodies-ring SmalltalkXProjects/stx/goodies/ring
+
+## Loading
+
+1.  Clone Powerlang:
+
+        git clone https://github.com/powerlang/powerlang.git
+
+2.  In Smalltalk/X workspace, execute:
+
+		"Load PetitParser"
+        Smalltalk loadPackage: 'stx:goodies/petitparser'.
+
+        "Load RING "
+        Smalltalk loadPackage:'stx:goodies/ring/core'.
+        Smalltalk loadPackage:'stx:goodies/ring/core/tests'.
+        Smalltalk loadPackage:'stx:goodies/ring/monticello'.
+        Smalltalk loadPackage:'stx:goodies/ring/tooling'.
+
+        "Load Powerlang"
+        ParserFlags allowInheritedPools: true.
+        Smalltalk packagePath add: '/where/you/cloned/powerlang/bootstrap/src'.
+        Smalltalk loadPackage: 'Powerlang-Compatibility-SmalltalkX'.
+        Smalltalk loadPackage: 'Powerlang-Core'.
+        Smalltalk loadPackage: 'Powerlang-Tests'.
+
+## Saving & Committing Changes
+
+1.  Make sure you have moved all code to desired package.
+
+2.  File out modified package(s):
+
+       1. switch browser to package view - *View* ▷ *Package*
+       2. then select modified package(s)
+       3. and file them out in Tonel format - *Package* ▷ *File out* ▷ *Special Formats* ▷ *Tonel as...*.
+       4. In file dialog, select directory where you want to file out packages (each package as a subdirectory). For example, if you cloned Powerlang to `/where/you/cloned/powerlang` then select `/where/you/cloned/powerlang/bootstrap/src`. In most cases, the correct directory should be pre-selected. but better check.
+
+3.  Use your favorite GIT client to commit changes to repository.
+
+[1]: https://swing.fit.cvut.cz/projects/stx-jv
+[2]: https://swing.fit.cvut.cz/download/smalltalkx/devel
+[3]: https://swing.fit.cvut.cz/projects/stx-jv/wiki/Documentation/BuildingStXWithRakefiles
+[4]: https://swing.fit.cvut.cz/hg/jv-libgdbs/file/tip/README.md

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Behavior.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Behavior.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Behavior }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Behavior >> configureCompiler: aCompiler [
+	
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Behavior >> isSpecies [
+	^true
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Block.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Block.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #Block }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Block >> evaluate [
+	^self value
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Block >> evaluateWith: anObject [
+	^self value: anObject
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Block >> evaluateWithArguments: anArray [
+	^self valueWithArguments: anArray  
+
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/CharacterArray.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/CharacterArray.extension.st
@@ -1,0 +1,80 @@
+Extension { #name : #CharacterArray }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> arity [
+	^self numArgs
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> existingSymbol [
+	^Symbol findInterned: self
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> indexOfString: aString from: start to: stop [
+	| n limit base i |
+	n := aString size.
+	limit := stop - n.
+	base := start - 1.
+	i := 1.
+	[
+		base > limit ifTrue: [^0].
+		i <= n]
+		whileTrue: [
+			i := (self at: base + i) = (aString at: i) ifTrue: [i + 1] ifFalse: [
+				base := base + 1.
+				1]].
+	^i > 1 ifTrue: [base + 1] ifFalse: [0]
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> indexOfSubcollection: aCollection startingAt: anInteger [
+	| m n i first |
+	m := aCollection size.
+	m = 0 ifTrue: [^0].
+	n := self size - m + 1.
+	i := anInteger.
+	first := aCollection at: 1.
+	[i <= n] whileTrue: [| j |
+		(self at: i) = first ifTrue: [
+			j := 2.
+			[j <= m and: [(self at: i + j - 1) = (aCollection at: j)]]
+				whileTrue: [j := j + 1].
+			j > m ifTrue: [^i]].
+		i := i + 1].
+	^0
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> reduced [
+	^self asSingleByteStringIfPossible
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> replaceAllSubstrings: aString with: anotherString [
+	| string strm index fragment n |
+	string := aString asString.
+	string isEmpty ifTrue: [^self].
+	index := self indexOfSubcollection: string startingAt: 1.
+	index = 0 ifTrue: [^self].
+	strm := self asString class new writeStream.
+	fragment := self copyFrom: 1 to: index - 1.
+	strm nextPutAll: fragment.
+	n := string size.
+	[index > 0] whileTrue: [| next limit |
+		next := self indexOfString: string from: index + n to: self size.
+		limit := next = 0 ifTrue: [self size + 1] ifFalse: [next].
+		fragment := self copyFrom: index + n - 1 + 1 to: limit - 1.
+		strm nextPutAll: anotherString; nextPutAll: fragment.
+		index := next].
+	^strm contents
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+CharacterArray >> withArticle [
+	| article |
+	article := self first isVowel ifTrue: ['an'] ifFalse: ['a'].
+	^article , ' ' , self
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/CharacterConstants.class.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/CharacterConstants.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #CharacterConstants,
+	#superclass : #PSharedPool,
+	#classVars : [
+		'Cr',
+		'Lf',
+		'Space',
+		'Tab'
+	],
+	#category : #'Powerlang-Compatibility-SmalltalkX'
+}
+
+{ #category : #'class initialization' }
+CharacterConstants class >> initialize [
+	Cr := Character cr.
+	Lf := Character lf.
+	Tab := Character tab.
+	Space := Character space.
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/ClassDescription.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/ClassDescription.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+ClassDescription >> allSharedPoolsUsing: globals [
+	^self sharedPools
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+ClassDescription >> indexOfSlot: instVarName [
+	^self instVarIndexFor: instVarName
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+ClassDescription >> localPools [
+	^#()
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Dictionary.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Dictionary.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Dictionary }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Dictionary >> removeAllSuchThat: aBlock [
+	"Evaluate aBlock for each element and remove all that elements from
+	the receiver for that aBlock evaluates to true.  Use a copy to enumerate 
+	collections whose order changes when an element is removed (i.e. Sets)."
+	self copy
+		keysAndValuesDo: [:key :each | (aBlock evaluateWith: each)
+			ifTrue: [self removeKey: key]]
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/False.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/False.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #False }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+False >> and: block1 andNot: block2 [
+	^self
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+False >> andNot: aBlock [
+	^self
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+False >> orNot: aBlock [
+	^aBlock value not
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Float.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Float.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Float }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Float >> pointerDouble [
+	^ (ByteArray new: ExternalBytes sizeofDouble)
+				doubleAt: 1 put: self;
+				yourself
+
+	"Created: / 03-02-2021 / 10:19:38 / Jan Vrany <jan.vrany@labware.com>"
+
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Integer.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Integer.extension.st
@@ -1,0 +1,88 @@
+Extension { #name : #Integer }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bin [
+	"
+	255 bin
+	"
+	^self radix: 2
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bin: bits [
+	"
+	(2 bin: 7) size = 7
+	"
+	| pad bin |
+	pad := String new: bits withAll: $0.
+	bin := pad , self bin.
+	^ bin copyFrom: bin size - bits + 1 to: bin size
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bitShiftRight: anInteger [
+	^self bitShift: 0 - anInteger
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bitsAt: aStretch [
+	"
+	(2r001101010 bitField: (3 thru: 6)) bin = '1010'
+	(-16r40000000 bitField: (29 thru: 31)) bin = '100'
+	"
+	| shifted mask |
+	shifted := self bitShiftRight: aStretch start - 1.
+	mask := 1 bitShift: aStretch length.
+	^shifted bitAnd: mask - 1
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bitsAt: aStretch put: anInteger [
+	"
+	((2r001101100 bitsAt: (3 thru: 6) put: 2r1101) bitField: (3 thru: 6)) bin = '1101'
+	((2r100 bitsAt: (29 thru: 31) put: 2r101) bitField: (29 thru: 31)) bin = '101'
+	((2r100 bitsAt: (29 thru: 31) put: 2r101) bitField: (1 thru: 3)) bin = '100'
+	"
+	| shifted max |
+	shifted := anInteger bitShift: aStretch start - 1.
+	max := 1 bitShift: aStretch length.
+	anInteger < max ifFalse: [self error: 'invalid argument'].
+	^(self bitsClear: aStretch) bitOr: shifted
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bitsClear: aStretch [
+	"
+	(2r111100110 bitsClear: (3 thru: 6)) = 2r111000010
+	"
+	| mask |
+	mask := (1 bitShift: aStretch end) - (1 bitShift: aStretch start - 1).
+	^self bitAnd: mask bitInvert
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> bytesCount [
+	self subclassResponsibility
+
+	"Created: / 03-02-2021 / 11:42:54 / Jan Vrany <jan.vrany@labware.com>"
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> isOnBit: n [
+	^(self bitAnd: n) = n
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Integer >> linearFeedbackShiftRandom: key [
+	"
+	LFSR implementation (avoids 0 by definition).
+	More keys at: https://users.ece.cmu.edu/~koopman/lfsr/index.html
+	"
+
+	| shifted |
+	shifted := self bitShift: -1.
+	^ (self bitAnd: 1) = 0
+		ifTrue: [ shifted ]
+		ifFalse: [ shifted bitXor: key ]
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/LargeInteger.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/LargeInteger.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #LargeInteger }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+LargeInteger >> bytesCount [
+	^ digitByteArray size
+
+	"Created: / 15-03-2021 / 15:09:59 / Jan Vrany <jan.vrany@labware.com>"
+
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/NumberParser2.class.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/NumberParser2.class.st
@@ -1,0 +1,225 @@
+Class {
+	#name : #NumberParser2,
+	#superclass : #Object,
+	#instVars : [
+		'stream',
+		'error',
+		'return'
+	],
+	#category : #'Powerlang-Compatibility-SmalltalkX'
+}
+
+{ #category : #private }
+NumberParser2 >> checkNumberEnd: position [
+	| char |
+	stream atEnd ifTrue: [^self].
+	char := stream peek.
+	char = $. ifFalse: [^self].
+	stream skip: 1.
+	stream atEnd
+		ifFalse: [stream peek isDigit
+			ifTrue: [self error: 'invalid number' at: position]].
+	stream skip: -1
+]
+
+{ #category : #private }
+NumberParser2 >> completeFloat: anInteger [
+	| tenth |
+	tenth := 10 raisedToInteger: self nextExponent.
+	^(anInteger * tenth) asFloat
+]
+
+{ #category : #private }
+NumberParser2 >> completeNumber: anInteger after: aCharacter [
+	aCharacter = $. ifTrue: [
+		^(stream peekFor: $s)
+			ifTrue: [self nextScaledFrom: anInteger fractionDigits: 0]
+			ifFalse: [self nextFloat: anInteger]].
+	(aCharacter = $e or: [aCharacter = $E])
+		ifTrue: [^self completeFloat: anInteger].
+	aCharacter = $r ifTrue: [^self nextIntegerRadix: anInteger].
+	aCharacter = $s ifTrue: [^self nextScaledFrom: anInteger fractionDigits: 0].
+	(anInteger = 0 and: [aCharacter = $x or: [aCharacter = $X]])
+		ifTrue: [^self nextIntegerRadix: 16].
+	stream skip: -1.
+	^anInteger
+]
+
+{ #category : #private }
+NumberParser2 >> completeNumber: anInteger at: start [
+	| number |
+	stream atEnd ifTrue: [^anInteger].
+	number := anInteger.
+	number := self completeNumber: anInteger after: stream next.
+	self checkNumberEnd: start.
+	^number
+]
+
+{ #category : #private }
+NumberParser2 >> digitFromChar: char base: radix [
+	| c |
+	char isDigit ifTrue: [^char digitValue].
+	char = $r ifTrue: [^nil].
+	char = $x ifTrue: [^nil].
+	char = $X ifTrue: [^nil].
+	c := char asUppercase.
+	(c asInteger between: $A asInteger and: $Z asInteger) ifFalse: [^nil].
+	(c != $E and: [radix <= c digitValue]) ifTrue: [^nil].
+	(c = $E and: [radix = 10]) ifTrue: [^nil].
+	^c digitValue
+]
+
+{ #category : #private }
+NumberParser2 >> endToken [
+	self error: 'end of stream' at: stream position
+]
+
+{ #category : #accessing }
+NumberParser2 >> error [
+	^error
+]
+
+{ #category : #private }
+NumberParser2 >> error: aString at: position [
+	error := aString -> position.
+	return value: nil
+]
+
+{ #category : #private }
+NumberParser2 >> negativeNumber [
+	| position |
+	stream atEnd ifTrue: [^nil].
+	stream peek isDigit ifFalse: [^nil].
+	position := stream position.
+	^self next key negated -> position
+]
+
+{ #category : #private }
+NumberParser2 >> next [
+	| char |
+	return isNil ifTrue: [return := [:value | ^value]].
+	char := self nextChar.
+	char isNil ifTrue: [^self endToken].
+	char = $- ifTrue: [^self negativeNumber].
+	char = $+ ifTrue: [^self positiveNumber].
+	char isDigit ifTrue: [^self nextNumber: char].
+	^nil
+]
+
+{ #category : #private }
+NumberParser2 >> nextChar [
+	^(stream skipSeparators; atEnd) ifFalse: [stream next]
+
+]
+
+{ #category : #private }
+NumberParser2 >> nextDigit: radix [
+	| char digit |
+	stream atEnd ifTrue: [^nil].
+	char := stream next.
+	digit := self digitFromChar: char base: radix.
+	digit isNil ifTrue: [
+		stream skip: -1.
+		^nil].
+	radix <= digit
+		ifTrue: [self error: 'digit greater than radix' at: stream position].
+	^digit
+]
+
+{ #category : #private }
+NumberParser2 >> nextExponent [
+	| negated exp |
+	negated := false.
+	(stream peekFor: $+) ifFalse: [negated := stream peekFor: $-].
+	exp := self nextIntegerRadix: 10.
+	negated ifTrue: [exp := exp negated].
+	^exp
+]
+
+{ #category : #private }
+NumberParser2 >> nextFloat: aNumber [
+	| base digit e exp |
+	digit := self nextDigit: 10.
+	digit isNil ifTrue: [
+		stream skip: -1.
+		^aNumber].
+	e := 1.
+	base := aNumber * 10 + digit.
+	[
+		digit := self nextDigit: 10.
+		digit isNil]
+		whileFalse: [
+			base := base * 10 + digit.
+			e := e + 1].
+	((stream peekFor: $E) or: [stream peekFor: $e]) ifTrue: [
+		exp := self nextExponent.
+		^(base * (10 raisedToInteger: exp - e)) asFloat].
+	(stream peekFor: $s) ifTrue: [^self nextScaledFrom: base fractionDigits: e].
+	^(base * (10 raisedToInteger: e negated)) asFloat
+]
+
+{ #category : #private }
+NumberParser2 >> nextIntegerRadix: radix [
+	| value valid digit |
+	value := 0.
+	valid := false.
+	[
+		digit := self nextDigit: radix.
+		digit isNil]
+		whileFalse: [
+			valid := true.
+			value := value * radix + digit].
+	valid ifFalse: [self error: 'digit missing' at: stream position + 1].
+	^value
+]
+
+{ #category : #private }
+NumberParser2 >> nextNumber: aCharacter [
+	| start number digit |
+	start := stream position.
+	number := aCharacter digitValue.
+	[
+		digit := self nextDigit: 10.
+		digit isNil]
+		whileFalse: [number := number * 10 + digit].
+	number := self completeNumber: number at: start.
+	^number -> (start thru: stream position)
+]
+
+{ #category : #private }
+NumberParser2 >> nextScaledFrom: aNumber fractionDigits: digits [
+	| scale denominator sd |
+	scale := (stream atEnd not and: [stream peek isDigit])
+		ifTrue: [self nextIntegerRadix: 10].
+	denominator := 10 raisedToInteger: digits.
+	sd := ScaledDecimal
+		numerator: aNumber
+		denominator: denominator
+		scale: scale.
+	^sd reduced
+]
+
+{ #category : #services }
+NumberParser2 >> nextValue [
+	^self next ifNil: [0] ifNotNil: [:assoc | assoc key]
+]
+
+{ #category : #accessing }
+NumberParser2 >> on: aString [
+	stream := aString readStream.
+	return := nil
+]
+
+{ #category : #private }
+NumberParser2 >> positiveNumber [
+	| position |
+	stream peek isDigit ifFalse: [^nil].
+	position := stream position.
+	^self next key -> position
+]
+
+{ #category : #private }
+NumberParser2 >> reset [
+	stream reset.
+	return := nil
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Object.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Object.extension.st
@@ -1,0 +1,141 @@
+Extension { #name : #Object }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> != anObject [
+		^ self ~= anObject
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> !== anObject [
+	^self ~~ anObject
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> ASSERT: aBoolean [
+	self assert: aBoolean
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> DENY: aBoolean [
+	self ASSERT: aBoolean not
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object class >> disableCode: aBlock [
+	"the block has been disabled"
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> evaluate [
+	^self
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> evaluateWith: anObject [
+	^self evaluateWithArguments: {anObject}
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> evaluateWithArguments: anArray [
+	^self evaluate
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashWith: a [
+	^self
+		hashedWith: a
+		with: nil
+		with: nil
+		with: nil
+		with: nil
+		with: nil
+		count: 2
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashWith: a with: b [
+	^ self
+		hashedWith: a
+		with: b
+		with: nil
+		with: nil
+		with: nil
+		with: nil
+		count: 3
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashWith: a with: b with: c [
+	^self
+		hashedWith: a
+		with: b
+		with: c
+		with: nil
+		with: nil
+		with: nil
+		count: 4
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashWith: a with: b with: c with: d [
+	^ self
+		hashedWith: a
+		with: b
+		with: c
+		with: d
+		with: nil
+		with: nil
+		count: 5
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashWith: a with: b with: c with: d with: e [
+	^ self
+		hashedWith: a
+		with: b
+		with: c
+		with: d
+		with: e
+		with: nil
+		count: 6
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> hashedWith: a
+with: b
+with: c
+with: d
+with: e
+with: f
+count: n [
+	| hash |
+	hash := n hashMultiply bitXor: self hash.
+	hash := hash hashMultiply bitXor: a hash.
+	n = 2 ifTrue: [^hash].
+	hash := hash hashMultiply bitXor: b hash.
+	n = 3 ifTrue: [^hash].
+	hash := hash hashMultiply bitXor: c hash.
+	n = 4 ifTrue: [^hash].
+	hash := hash hashMultiply bitXor: d hash.
+	n = 5 ifTrue: [^hash].
+	hash := hash hashMultiply bitXor: e hash.
+	n = 6 ifTrue: [^hash].
+	hash := hash hashMultiply bitXor: f hash.
+	n = 7 ifTrue: [^hash].
+	self error: 'Invalid argument count'
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> isSmallInteger [
+	^false
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> isSpecies [
+	^false
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Object >> primitivePrintString [
+	^self printString
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/OrderedDictionary.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/OrderedDictionary.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #OrderedDictionary }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+OrderedDictionary >> withIndexDo: aBlock [
+	| i |
+	i := 1.
+	self do: [:each | 
+		aBlock value: each value: i.
+		i := i + 1]
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PSharedPool.class.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PSharedPool.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #PSharedPool,
+	#superclass : #SharedPool,
+	#category : #'Powerlang-Compatibility-SmalltalkX'
+}
+
+{ #category : #accessing }
+PSharedPool class >> asArray [
+	^ Array streamContents: [:s | self do:[:e | s nextPut: e]]
+]
+
+{ #category : #accessing }
+PSharedPool class >> detect: aOneArgBlock ifNone: exceptionValue [
+	self do:[:each | 
+		(aOneArgBlock value:each) ifTrue:[^ each].
+	].
+	^ exceptionValue value    
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PoolDictionary.class.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PoolDictionary.class.st
@@ -1,0 +1,72 @@
+Class {
+	#name : #PoolDictionary,
+	#superclass : #Dictionary,
+	#instVars : [
+		'constant'
+	],
+	#category : #'Powerlang-Compatibility-SmalltalkX'
+}
+
+{ #category : #'instance creation' }
+PoolDictionary class >> newConstantPool [
+	^self new beConstantPool
+]
+
+{ #category : #adding }
+PoolDictionary >> add: anAssociation [
+	anAssociation key isString
+		ifFalse: [self error: 'Pools are keyed with Strings'].
+	^super add: anAssociation
+]
+
+{ #category : #accessing }
+PoolDictionary >> at: key [
+	^super at: key asString reduced
+]
+
+{ #category : #accessing }
+PoolDictionary >> at: key ifAbsent: aBlock [
+	^super at: key asString reduced ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+PoolDictionary >> at: key ifPresent: aBlock [
+	^super at: key asString reduced ifPresent: aBlock
+]
+
+{ #category : #accessing }
+PoolDictionary >> at: key put: value [
+	^super at: key asString put: value
+]
+
+{ #category : #accessing }
+PoolDictionary >> beConstant: aBoolean [
+	constant := aBoolean
+]
+
+{ #category : #accessing }
+PoolDictionary >> beConstantPool [
+	constant := true
+]
+
+{ #category : #inquiries }
+PoolDictionary >> includesKey: key [
+	^super includesKey: key asString reduced
+]
+
+{ #category : #initialization }
+PoolDictionary >> initialize: anInteger [
+	super initialize: anInteger.
+	constant := false
+]
+
+{ #category : #testing }
+PoolDictionary >> isConstant [
+	^constant
+]
+
+{ #category : #removing }
+PoolDictionary >> removeKey: key ifAbsent: aBlock [
+	super removeKey: key asString reduced ifAbsent: aBlock.
+	^key
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PositionableStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/PositionableStream.extension.st
@@ -1,0 +1,65 @@
+Extension { #name : #PositionableStream }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint16le [
+	"Answer the next unsigned, 16-bit integer from this (binary) stream."
+
+	^ self next + (self next bitShift: 8)
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint16le: anInteger [
+	"Store the given unsigned, 32-bit integer as little endian 
+	 on this (binary) stream."
+
+	(anInteger < 0 or: [ anInteger >= 16r10000 ])
+		ifTrue: [ self error: 'outside unsigned 16-bit integer range' ].
+	self nextPut: (anInteger byteAt: 1).
+	self nextPut: (anInteger byteAt: 2)
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint32le [
+	"Answer the next unsigned, 32-bit integer from this (binary) stream."
+
+	^self next + (self next bitShift: 8) + (self next bitShift: 16) + (self next bitShift: 24)
+	
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint32le: anInteger [
+	"Store the given unsigned, 32-bit integer as little endian 
+	 on this (binary) stream."
+
+	(anInteger < 0 or: [ anInteger >= 16r100000000 ])
+		ifTrue: [ self error: 'outside unsigned 32-bit integer range' ].
+	self nextPut: (anInteger byteAt: 1).
+	self nextPut: (anInteger byteAt: 2).
+	self nextPut: (anInteger byteAt: 3).
+	self nextPut: (anInteger byteAt: 4)
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint64le [
+	"Answer the next unsigned, 64-bit integer from this (binary) stream."
+
+	^ self next + (self next bitShift: 8) + (self next bitShift: 16)
+		+ (self next bitShift: 24) + (self next bitShift: 32)
+		+ (self next bitShift: 40) + (self next bitShift: 48)
+		+ (self next bitShift: 56)
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+PositionableStream >> uint64le: anInteger [
+	"Store the given unsigned, 64-bit integer as little endian 
+	 on this (binary) stream."
+
+	self nextPut: (anInteger byteAt: 1).
+	self nextPut: (anInteger byteAt: 2).
+	self nextPut: (anInteger byteAt: 3).
+	self nextPut: (anInteger byteAt: 4).
+	self nextPut: (anInteger byteAt: 5).
+	self nextPut: (anInteger byteAt: 6).
+	self nextPut: (anInteger byteAt: 7).
+	self nextPut: (anInteger byteAt: 8)
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/ReadStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/ReadStream.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #ReadStream }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+ReadStream >> peek: n [
+	| pos data |
+	pos := self position.
+	data := self nextAvailable: n.
+	self position: pos.
+	^data
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+ReadStream >> prev [
+	^self position > 0
+		ifTrue: [self position: self position - 1; peek]
+		ifFalse: [self error: 'read beyond start of stream']
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/SequenceableCollection.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/SequenceableCollection.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #SequenceableCollection }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+SequenceableCollection >> beeCopyFrom: start [
+	^self beeCopyFrom: start to: self size
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+SequenceableCollection >> beeCopyFrom: start to: stop [
+	| size copy |
+	size := stop - start + 1 max: 0.
+	copy := self species ofSize: size.
+	^copy
+		replaceFrom: 1
+		to: size
+		with: self
+		startingAt: start
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/SmallInteger.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/SmallInteger.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #SmallInteger }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+SmallInteger >> bytesCount [
+
+	^ self shouldNotImplement
+
+	"Created: / 03-02-2021 / 11:43:19 / Jan Vrany <jan.vrany@labware.com>"
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+SmallInteger >> isSmallInteger [
+	^ true
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Smalltalk.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Smalltalk.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : #Smalltalk }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Smalltalk class >> host [
+	"Return current host identification string (that is, identification
+	of machine the smalltalk is currently running on). 
+
+	The format of the string is that of GNU triplets except that 'vendor'
+	part is ommited (mostly unused these days anyway). 
+
+	Examples:   
+					* x86_64-linux-gnu 
+					* x86_64-win32
+					* riscv64-linux-gnu
+	"
+
+	| triplet i1 i2 |
+
+	triplet := self configuration.
+	i1 := triplet indexOf: $-.
+	i2 := triplet indexOf: $- startingAt: i1 + 1.
+	^ (triplet copyTo: i1 -1 ) , '-' , (triplet copyFrom: i2 + 1)
+
+	"
+	Smalltalk host
+	ABI currentClass
+	"
+
+	"Created: / 13-04-2021 / 14:54:17 / Jan Vrany <jan.vrany@labware.com>"
+
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Stream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Stream.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Stream }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Stream >> sizeToEnd [
+	^self size - self position
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+Stream >> skip [
+	self skip: 1
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Stretch.class.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/Stretch.class.st
@@ -1,0 +1,122 @@
+Class {
+	#name : #Stretch,
+	#superclass : #Object,
+	#instVars : [
+		'start',
+		'end'
+	],
+	#category : #'Powerlang-Compatibility-SmalltalkX'
+}
+
+{ #category : #'instance creation' }
+Stretch class >> from: start thru: end [
+	^self new start: start; end: end
+]
+
+{ #category : #arithmetic }
+Stretch >> + delta [
+	delta isInteger ifTrue: [^start + delta thru: end + delta].
+	delta isPoint ifTrue: [^start + delta x thru: end + delta y].
+	^start + delta start thru: end + delta end
+]
+
+{ #category : #arithmetic }
+Stretch >> - delta [
+	^self + delta negated
+]
+
+{ #category : #arithmetic }
+Stretch >> // anInteger [
+	^start // anInteger thru: end // anInteger
+]
+
+{ #category : #comparing }
+Stretch >> = aStretch [
+	self class == aStretch class ifFalse: [^false].
+	^start = aStretch start and: [end = aStretch end]
+]
+
+{ #category : #arithmetic }
+Stretch >> center [
+	^start + end // 2
+]
+
+{ #category : #arithmetic }
+Stretch >> down: anInteger [
+	^start thru: end + anInteger
+]
+
+{ #category : #accessing }
+Stretch >> end [
+	^end
+]
+
+{ #category : #accessing }
+Stretch >> end: anInteger [
+	end := anInteger
+]
+
+{ #category : #comparing }
+Stretch >> hash [
+	^start hashWith: end
+]
+
+{ #category : #testing }
+Stretch >> includes: anInteger [
+	^anInteger between: start and: end
+]
+
+{ #category : #testing }
+Stretch >> intersects: aStretch [
+	self isEmpty ifTrue: [^false].
+	(aStretch includes: start) ifTrue: [^true].
+	^aStretch includes: end
+]
+
+{ #category : #testing }
+Stretch >> isEmpty [
+	^end < start
+]
+
+{ #category : #arithmetic }
+Stretch >> length [
+	^end - start + 1
+]
+
+{ #category : #arithmetic }
+Stretch >> max [
+	^start max: end
+]
+
+{ #category : #arithmetic }
+Stretch >> min [
+	^start min: end
+]
+
+{ #category : #arithmetic }
+Stretch >> negated [
+	^start negated thru: end negated
+]
+
+{ #category : #testing }
+Stretch >> notEmpty [
+	^start <= end
+]
+
+{ #category : #printing }
+Stretch >> printOn: aStream [
+	aStream
+		nextPutAll: start asString;
+		nextPutAll: ' thru: ';
+		nextPutAll: end asString
+]
+
+{ #category : #accessing }
+Stretch >> start [
+	^start
+]
+
+{ #category : #accessing }
+Stretch >> start: anInteger [
+	start := anInteger
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/String.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/String.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #String }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+String >> trimBlanks [
+	^self trim
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/True.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/True.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #True }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+True >> and: block1 andNot: block2 [
+	^block1 value andNot: [block2 value]
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+True >> andNot: aBlock [
+	^aBlock value not
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+True >> orNot: aBlock [
+	^self
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : #WriteStream }
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+WriteStream >> nextBytePut: aCollection [
+	^ self nextPut: aCollection
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+WriteStream >> nextBytesPut: aCollection [
+	^self nextPutAll: aCollection
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+WriteStream >> nextLongPut: anInteger [
+	| unsigned |
+	unsigned := anInteger < 0 ifTrue: [ anInteger + (1 << 32) ] ifFalse: [ anInteger  ]
+.self nextULongPut: unsigned.
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
+WriteStream >> nextULongPut: anInteger [
+	1 to: 4 do: [ :i | 
+		| bi |
+		bi := anInteger byteAt: i.
+		self nextPut: bi ]
+]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/package.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Powerlang-Compatibility-SmalltalkX' }

--- a/bootstrap/src/Powerlang-Core/ArgumentBinding.class.st
+++ b/bootstrap/src/Powerlang-Core/ArgumentBinding.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler-Bindings'
 }
 
+{ #category : #'instance creation' }
+ArgumentBinding class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #actions }
 ArgumentBinding >> beInlined [
 	environment := InlinedArgEnvironment new

--- a/bootstrap/src/Powerlang-Core/AstcodeDecoder.class.st
+++ b/bootstrap/src/Powerlang-Core/AstcodeDecoder.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'Powerlang-Core-SExpressions'
 }
 
+{ #category : #'instance creation' }
+AstcodeDecoder class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #public }
 AstcodeDecoder >> bindingTypeOf: id [
 	^bindingTypes at: id

--- a/bootstrap/src/Powerlang-Core/AstcodeEncoder.class.st
+++ b/bootstrap/src/Powerlang-Core/AstcodeEncoder.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'Powerlang-Core-SExpressions'
 }
 
+{ #category : #'instance creation' }
+AstcodeEncoder class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #visiting }
 AstcodeEncoder >> compiledBlockIndexOf: aBlockNode [
 	| index |

--- a/bootstrap/src/Powerlang-Core/ByteObjectMap.class.st
+++ b/bootstrap/src/Powerlang-Core/ByteObjectMap.class.st
@@ -9,6 +9,14 @@ Class {
 }
 
 { #category : #'instance creation' }
+ByteObjectMap class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
+{ #category : #'instance creation' }
 ByteObjectMap class >> new: anRGBehavior size: anInteger [
 
 	^ self new

--- a/bootstrap/src/Powerlang-Core/CompositeMessageLinker.class.st
+++ b/bootstrap/src/Powerlang-Core/CompositeMessageLinker.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'Powerlang-Core-Nativization'
 }
 
+{ #category : #'instance creation' }
+CompositeMessageLinker class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #services }
 CompositeMessageLinker >> add: aMessageLinker [
 	candidates add: aMessageLinker

--- a/bootstrap/src/Powerlang-Core/EmulationLookup.class.st
+++ b/bootstrap/src/Powerlang-Core/EmulationLookup.class.st
@@ -9,6 +9,14 @@ Class {
 	#category : #'Powerlang-Core-Metaphysics'
 }
 
+{ #category : #'instance creation' }
+EmulationLookup class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 EmulationLookup >> compile: anRGMethod [
 	| compiler method |

--- a/bootstrap/src/Powerlang-Core/ImageSegmentBuilder.class.st
+++ b/bootstrap/src/Powerlang-Core/ImageSegmentBuilder.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'Powerlang-Core-Building'
 }
 
+{ #category : #'instance creation' }
+ImageSegmentBuilder class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #initialization }
 ImageSegmentBuilder >> => aSymbol [
 	^ self spec at: aSymbol

--- a/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
+++ b/bootstrap/src/Powerlang-Core/ImageSegmentWriter.class.st
@@ -26,6 +26,14 @@ ImageSegmentWriter class >> behaviorOffset [
 	^ -4
 ]
 
+{ #category : #'instance creation' }
+ImageSegmentWriter class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 ImageSegmentWriter class >> nilOffset [
 	^self objectsOffset + 8

--- a/bootstrap/src/Powerlang-Core/InlineMessageLinker.class.st
+++ b/bootstrap/src/Powerlang-Core/InlineMessageLinker.class.st
@@ -12,6 +12,14 @@ Class {
 	#category : #'Powerlang-Core-Nativization'
 }
 
+{ #category : #'instance creation' }
+InlineMessageLinker class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #private }
 InlineMessageLinker class >> supported [
 	| selectors |

--- a/bootstrap/src/Powerlang-Core/InvokeLinker.class.st
+++ b/bootstrap/src/Powerlang-Core/InvokeLinker.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #'Powerlang-Core-Nativization'
 }
 
+{ #category : #'instance creation' }
+InvokeLinker class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #nativizing }
 InvokeLinker >> addMethod: aCompiledMethod [
 	self addMethod: aCompiledMethod for: aCompiledMethod selector

--- a/bootstrap/src/Powerlang-Core/LazyLinker.class.st
+++ b/bootstrap/src/Powerlang-Core/LazyLinker.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'Powerlang-Core-Nativization'
 }
 
+{ #category : #'instance creation' }
+LazyLinker class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #nativizing }
 LazyLinker >> emitSend: aSymbol using: anAssembler [
 	| send |

--- a/bootstrap/src/Powerlang-Core/MemoryOperand.class.st
+++ b/bootstrap/src/Powerlang-Core/MemoryOperand.class.st
@@ -35,6 +35,14 @@ MemoryOperand class >> fromString: aString [
 	^self fromStream: aString readStream
 ]
 
+{ #category : #'instance creation' }
+MemoryOperand class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #comparing }
 MemoryOperand >> = operand [
 	self class == operand class ifFalse: [^false].

--- a/bootstrap/src/Powerlang-Core/MethodEvaluator.class.st
+++ b/bootstrap/src/Powerlang-Core/MethodEvaluator.class.st
@@ -33,6 +33,14 @@ MethodEvaluator class >> initialize [
 	Undermessages := #(_basicAt: #_basicAt:put: _bitShiftLeft: _byteAt: #_byteAt:put: _smallSize _largeSize _isSmallInteger _basicHash _basicHash: _smallIntegerByteAt: _uShortAtOffset: _uShortAtOffset:put:)
 ]
 
+{ #category : #'instance creation' }
+MethodEvaluator class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #visiting }
 MethodEvaluator >> argumentAt: index in: anInteger [
 	| env |

--- a/bootstrap/src/Powerlang-Core/ModRM.class.st
+++ b/bootstrap/src/Powerlang-Core/ModRM.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #'Powerlang-Core-Assembler-Tools'
 }
 
+{ #category : #'instance creation' }
+ModRM class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #private }
 ModRM >> beRR [
 	self mod: 2r11

--- a/bootstrap/src/Powerlang-Core/NativeCodeReference.class.st
+++ b/bootstrap/src/Powerlang-Core/NativeCodeReference.class.st
@@ -15,6 +15,14 @@ NativeCodeReference class >> absoluteFor: anObject [
 	^(self new for: anObject) beAbsolute
 ]
 
+{ #category : #'instance creation' }
+NativeCodeReference class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 NativeCodeReference >> beAbsolute [
 	absolute := true

--- a/bootstrap/src/Powerlang-Core/NativizationEnvironment.class.st
+++ b/bootstrap/src/Powerlang-Core/NativizationEnvironment.class.st
@@ -38,6 +38,14 @@ NativizationEnvironment class >> indexOfGlobal: aSymbol [
 		ifAbsent: [self error: 'global not found']
 ]
 
+{ #category : #'instance creation' }
+NativizationEnvironment class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #initialization }
 NativizationEnvironment >> abi [
 	^ abi 

--- a/bootstrap/src/Powerlang-Core/OSimpleLiveRange.class.st
+++ b/bootstrap/src/Powerlang-Core/OSimpleLiveRange.class.st
@@ -15,6 +15,14 @@ Class {
 	#category : #'Powerlang-Core-OCompiler-IR'
 }
 
+{ #category : #'instance creation' }
+OSimpleLiveRange class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #unclassified }
 OSimpleLiveRange >> addUseFrom: operation at: block [
 	uses add: operation -> block

--- a/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
+++ b/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : #'Powerlang-Core-Assembler-JIT'
 }
 
+{ #category : #'instance creation' }
+RelocatableBuffer class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #fixups }
 RelocatableBuffer >> addAbsoluteFixup: label [
 	| fixup |

--- a/bootstrap/src/Powerlang-Core/SAssignment.class.st
+++ b/bootstrap/src/Powerlang-Core/SAssignment.class.st
@@ -13,6 +13,14 @@ SAssignment class >> decodeUsing: anAstcodeDecoder [
 	^anAstcodeDecoder decodeAssignment
 ]
 
+{ #category : #'instance creation' }
+SAssignment class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #visiting }
 SAssignment >> acceptVisitor: visitor [
 	^visitor visitAssignment: self

--- a/bootstrap/src/Powerlang-Core/SCompiledBlock.class.st
+++ b/bootstrap/src/Powerlang-Core/SCompiledBlock.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler'
 }
 
+{ #category : #'instance creation' }
+SCompiledBlock class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #constants }
 SCompiledBlock >> argumentCount [
 	^format bitsAt: ArgCount

--- a/bootstrap/src/Powerlang-Core/SCompiledMethod.class.st
+++ b/bootstrap/src/Powerlang-Core/SCompiledMethod.class.st
@@ -17,6 +17,14 @@ Class {
 }
 
 { #category : #'instance creation' }
+SCompiledMethod class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
+{ #category : #'instance creation' }
 SCompiledMethod class >> new: anInteger [
 	^ (self basicNew: anInteger) initialize
 ]

--- a/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
+++ b/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
@@ -158,6 +158,14 @@ SExpressionNativizer class >> nativize: aCompiledMethod [
 		nativize: aCompiledMethod
 ]
 
+{ #category : #'instance creation' }
+SExpressionNativizer class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #services }
 SExpressionNativizer >> addFallback: aBlock [
 	fallbacks add: aBlock

--- a/bootstrap/src/Powerlang-Core/SMessage.class.st
+++ b/bootstrap/src/Powerlang-Core/SMessage.class.st
@@ -15,6 +15,14 @@ SMessage class >> decodeUsing: anAstcodeDecoder [
 	^anAstcodeDecoder decodeMessage
 ]
 
+{ #category : #'instance creation' }
+SMessage class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #printing }
 SMessage >> acceptVisitor: visitor [
 	^visitor visitMessage: self

--- a/bootstrap/src/Powerlang-Core/SScript.class.st
+++ b/bootstrap/src/Powerlang-Core/SScript.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #'Powerlang-Core-SExpressions'
 }
 
+{ #category : #'instance creation' }
+SScript class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #printing }
 SScript >> argumentCount [
 	^compiledCode argumentCount

--- a/bootstrap/src/Powerlang-Core/SSemanticVisitor.class.st
+++ b/bootstrap/src/Powerlang-Core/SSemanticVisitor.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler'
 }
 
+{ #category : #'instance creation' }
+SSemanticVisitor class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #analizing }
 SSemanticVisitor >> analyzeAssignment: anAssignmentNode [
 	anAssignmentNode assignees

--- a/bootstrap/src/Powerlang-Core/SSmalltalkCompiler.class.st
+++ b/bootstrap/src/Powerlang-Core/SSmalltalkCompiler.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler-Smalltalk'
 }
 
+{ #category : #'instance creation' }
+SSmalltalkCompiler class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 SSmalltalkCompiler >> activate: aScriptNode while: aBlock [
 	| current |

--- a/bootstrap/src/Powerlang-Core/SToken.class.st
+++ b/bootstrap/src/Powerlang-Core/SToken.class.st
@@ -9,6 +9,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler-Smalltalk-Parser'
 }
 
+{ #category : #'instance creation' }
+SToken class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #printing }
 SToken >> comment [
 	^comments notNil ifTrue: [comments anyOne]

--- a/bootstrap/src/Powerlang-Core/SendSite.class.st
+++ b/bootstrap/src/Powerlang-Core/SendSite.class.st
@@ -14,6 +14,14 @@ Class {
 	#category : #'Powerlang-Core-Nativization'
 }
 
+{ #category : #'instance creation' }
+SendSite class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 SendSite >> beSuperSend [
 	format := format bitOr: IsSuperSend

--- a/bootstrap/src/Powerlang-Core/SlotObjectMap.class.st
+++ b/bootstrap/src/Powerlang-Core/SlotObjectMap.class.st
@@ -9,6 +9,14 @@ Class {
 }
 
 { #category : #'instance creation' }
+SlotObjectMap class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
+{ #category : #'instance creation' }
 SlotObjectMap class >> new: anRGBehavior size: size withAll: value [
 	| obj |
 	obj := self new: anRGBehavior size: size.

--- a/bootstrap/src/Powerlang-Core/StaticBinder.class.st
+++ b/bootstrap/src/Powerlang-Core/StaticBinder.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler'
 }
 
+{ #category : #'instance creation' }
+StaticBinder class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 StaticBinder >> at: aString [
 	^contents at: aString ifAbsent: nil

--- a/bootstrap/src/Powerlang-Core/TemporaryBinding.class.st
+++ b/bootstrap/src/Powerlang-Core/TemporaryBinding.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Powerlang-Core-SCompiler-Bindings'
 }
 
+{ #category : #'instance creation' }
+TemporaryBinding class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #printing }
 TemporaryBinding >> description [
 	^'temporary ' , name

--- a/bootstrap/src/Powerlang-Core/VEXPrefix.class.st
+++ b/bootstrap/src/Powerlang-Core/VEXPrefix.class.st
@@ -121,6 +121,14 @@ VEXPrefix class >> l [
 	^2r100
 ]
 
+{ #category : #'instance creation' }
+VEXPrefix class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #private }
 VEXPrefix class >> operandSizeOverrideBits [
 	^1

--- a/bootstrap/src/Powerlang-Core/VirtualDictionary.class.st
+++ b/bootstrap/src/Powerlang-Core/VirtualDictionary.class.st
@@ -19,6 +19,14 @@ VirtualDictionary class >> fromPool: aSlotObjectMap [
 ]
 
 { #category : #'instance creation' }
+VirtualDictionary class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
+{ #category : #'instance creation' }
 VirtualDictionary class >> withAll: variables [
 	^self withAll: variables constant: false
 ]

--- a/bootstrap/src/Powerlang-Core/VirtualSmalltalkImage.class.st
+++ b/bootstrap/src/Powerlang-Core/VirtualSmalltalkImage.class.st
@@ -32,6 +32,14 @@ VirtualSmalltalkImage class >> kernelSpec [
 	^ KernelSpec ifNil: [ KernelSpec := self newKernelSpec ]
 ]
 
+{ #category : #'instance creation' }
+VirtualSmalltalkImage class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #accessing }
 VirtualSmalltalkImage class >> newKernelSpec [
 	| root current repo spec |

--- a/bootstrap/src/Powerlang-Core/VirtualSmalltalkRuntime.class.st
+++ b/bootstrap/src/Powerlang-Core/VirtualSmalltalkRuntime.class.st
@@ -29,6 +29,14 @@ VirtualSmalltalkRuntime class >> initialize [
 	Undermessages := #(_basicAt: #_basicAt:put: _bitShiftLeft: _byteAt: #_byteAt:put: _smallSize _largeSize _isSmallInteger _basicHash _basicHash: _smallIntegerByteAt: _uShortAtOffset: #_uShortAtOffset:put:)
 ]
 
+{ #category : #'instance creation' }
+VirtualSmalltalkRuntime class >> new [
+	"return an initialized instance"
+
+	^ self basicNew initialize.
+
+]
+
 { #category : #services }
 VirtualSmalltalkRuntime >> booleanFrom: anObject [
 	anObject == image false


### PR DESCRIPTION
This PR aims to allow Powerlang development in Smalltalk/X in addition to Pharo.

In addition to giving me (@janvrany) a familiar working environment (just like some people prefer `vi` over `emacs` and so on) it would allow me to experiment with stuff available in St/X such as VDB GUI integration and/or [LLVM](https://swing.fit.cvut.cz/hg/jv-llvm-s/). 

Pharo is still considered as the reference environment, i.e., stuff should work there. Unless decided otherwise, nobody is obliged to test changes also under Smalltalk/X (should this PR be merged). 

At this moment, not all tests pass and not all support needed in Smalltalk/X (Tonel, RING, stx:libcompat changes) is upstreamed. However, it is complete enough so one can load it into Smalltalk/X, run the bootstrap process and even refactor. Once all the dependencies are upstreamed and teething problems are fixed, I'll change this draft to full PR. 

FYI: @shingarov , @tukanos