### PR TITLE
Port to Smalltalk/X - part 2

### DIFF
--- a/bootstrap/src/Powerlang-Compatibility-Pharo/SmalltalkImage.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-Pharo/SmalltalkImage.extension.st
@@ -4,3 +4,44 @@ Extension { #name : #SmalltalkImage }
 SmalltalkImage >> associationAt: aSymbol [
 	^globals associationAt: aSymbol
 ]
+
+{ #category : #'*Powerlang-Compatibility-Pharo' }
+SmalltalkImage >> host [
+	"Return current host identification string (that is, identification
+	of machine the smalltalk is currently running on). 
+
+	The format of the string is that of GNU triplets except that 'vendor'
+	part is ommited (mostly unused these days anyway). 
+
+	Examples:   
+			* x86_64-linux-gnu 
+			* x86_64-win32
+			* riscv64-linux-gnu
+			
+	CAVEAT: following code simply assumes that Pharo is used
+	on x86_64 systems only and also assumes that if the OS is 
+	not Windows nor macOS, it must be Linux (and not, for instance,
+	FreeBSD or Solaris). 
+
+	Is there a standard way to figure that out? 
+	"
+	
+	| platform |
+	
+	platform := OSPlatform current.
+		
+	(platform isWin64 or: [platform isWin32 and: [Smalltalk vm wordSize = 8]]) ifTrue: [ ^'x86_64-win32' ].
+	platform isMacOSX ifTrue:[ ^'x86_64-darwin' ].
+	platform isUnix64 ifTrue:[ ^'x86_64-linux-gnu' ].
+	
+	self error: 'Unknown host!'
+	
+	
+
+
+
+
+
+
+
+]

--- a/bootstrap/src/Powerlang-Compatibility-Pharo/SmalltalkImage.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-Pharo/SmalltalkImage.extension.st
@@ -6,6 +6,21 @@ SmalltalkImage >> associationAt: aSymbol [
 ]
 
 { #category : #'*Powerlang-Compatibility-Pharo' }
+SmalltalkImage >> getPackageDirectoryForPackage: anRPackage [
+	"Return a directory from which given package has been loaded.
+	 
+	 CAVEAT: This only works for packages loaded from GIT repository and
+	 having in registered in Iceberg"
+	
+	| repo |
+	repo := IceRepository registry 
+					detect:[ :each | each loadedPackages contains: [:icep | icep name = anRPackage name ] ]
+					ifNone:[ ^ nil ].
+	^repo codeDirectory / anRPackage name
+
+]
+
+{ #category : #'*Powerlang-Compatibility-Pharo' }
 SmalltalkImage >> host [
 	"Return current host identification string (that is, identification
 	of machine the smalltalk is currently running on). 

--- a/bootstrap/src/Powerlang-Core/ABI.class.st
+++ b/bootstrap/src/Powerlang-Core/ABI.class.st
@@ -13,11 +13,14 @@ Class {
 
 { #category : #unclassified }
 ABI class >> currentClass [
-	| platform |
-	platform := OSPlatform current.
-	(platform isWin64 or: [platform isWin32 and: [Smalltalk vm wordSize = 8]]) ifTrue: [ ^WinX64ABI ].
-	(platform isUnix64 or: [platform isMacOSX]) ifTrue: [ ^SysVX64ABI ].
-	self ASSERT: false.
+	| host |
+	
+	host := Smalltalk host.
+	host = 'x86_64-linux-gnu' ifTrue:[ ^SysVX64ABI ].
+	host = 'x86_64-darwin' ifTrue:[ ^SysVX64ABI ].
+	host = 'x86_64-win32' ifTrue:[ ^WinX64ABI ].
+	
+	self error:'Unssuported host: ', host.
 ]
 
 { #category : #unclassified }

--- a/bootstrap/src/Powerlang-Core/VirtualSmalltalkImage.class.st
+++ b/bootstrap/src/Powerlang-Core/VirtualSmalltalkImage.class.st
@@ -34,12 +34,15 @@ VirtualSmalltalkImage class >> kernelSpec [
 
 { #category : #accessing }
 VirtualSmalltalkImage class >> newKernelSpec [
-	| current repo spec |
-	current := 'specs/current' asFileReference contents trim.
+	| root current repo spec |
+
+	root := (Smalltalk getPackageDirectoryForPackage: self package) / '..' / '..'.	
+	current := (root / 'specs' / 'current') contents asString trim.
 	repo := TonelRepository new
-		directory: ('specs/' , current) asFileReference.
+		directory: (root / 'specs' / current).
 	spec := repo asRingEnvironmentWith: #(Kernel).
 	^ spec clean
+
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This PR contains another two commits allowing port to St/X (and possibly other smalltalks). Originally this code used
`#isSmalltalkX`-style but this PR uses (extension) methods defined on `Smalltalk` object - each dialect compat package is then required to implement them. 

Hope this will be better-received. 