### PR TITLE
Add assembler GIGO tests

### DIFF
--- a/bootstrap/GNUmakefile
+++ b/bootstrap/GNUmakefile
@@ -16,7 +16,7 @@ bootstrap.image: pharo Pharo.image src
 	@echo ""
 
 test: bootstrap.image pharo specs/current
-	./pharo $< test --junit-xml-output Powerlang-Tests
+	./pharo $< test --fail-on-failure --junit-xml-output Powerlang-Tests
 	mkdir -p test-reports
 	mv Powerlang-Tests-Test.xml test-reports
 

--- a/bootstrap/src/Powerlang-Compatibility-Pharo/WriteStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-Pharo/WriteStream.extension.st
@@ -11,10 +11,26 @@ WriteStream >> nextBytesPut: aCollection [
 ]
 
 { #category : #'*Powerlang-Compatibility-Pharo' }
+WriteStream >> nextLargePut: anInteger [
+	| unsigned |
+	unsigned := anInteger < 0 ifTrue: [ anInteger + (1 << 64) ] ifFalse: [ anInteger  ]
+.self nextULargePut: unsigned.
+]
+
+{ #category : #'*Powerlang-Compatibility-Pharo' }
 WriteStream >> nextLongPut: anInteger [
 	| unsigned |
 	unsigned := anInteger < 0 ifTrue: [ anInteger + (1 << 32) ] ifFalse: [ anInteger  ]
 .self nextULongPut: unsigned.
+]
+
+{ #category : #'*Powerlang-Compatibility-Pharo' }
+WriteStream >> nextULargePut: anInteger [
+	1 to: 8 do: [ :i | 
+		| bi |
+		bi := anInteger byteAt: i.
+		self nextPut: bi ]
+
 ]
 
 { #category : #'*Powerlang-Compatibility-Pharo' }

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
@@ -13,15 +13,25 @@ WriteStream >> nextBytesPut: aCollection [
 
 { #category : #'*Powerlang-Compatibility-SmalltalkX' }
 WriteStream >> nextLongPut: anInteger [
-	| unsigned |
-	unsigned := anInteger < 0 ifTrue: [ anInteger + (1 << 32) ] ifFalse: [ anInteger  ]
-.self nextULongPut: unsigned.
+	self nextPutInt32: anInteger MSB: false.
+
 ]
 
 { #category : #'*Powerlang-Compatibility-SmalltalkX' }
 WriteStream >> nextULongPut: anInteger [
-	1 to: 4 do: [ :i | 
-		| bi |
-		bi := anInteger byteAt: i.
-		self nextPut: bi ]
+	|hh hl lh ll|
+
+	self ASSERT: anInteger >= 0.
+
+	ll := anInteger bitAnd: 16rFF.
+	lh := (anInteger bitShift: -8 ) bitAnd: 16rFF.
+	hl := (anInteger bitShift: -16) bitAnd: 16rFF.
+	hh := (anInteger bitShift: -24) bitAnd: 16rFF.
+
+	"low bytes first"
+	self nextPutByte:ll.
+	self nextPutByte:lh.
+	self nextPutByte:hl.
+	self nextPutByte:hh.       
+
 ]

--- a/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
+++ b/bootstrap/src/Powerlang-Compatibility-SmalltalkX/WriteStream.extension.st
@@ -12,6 +12,12 @@ WriteStream >> nextBytesPut: aCollection [
 ]
 
 { #category : #'*Powerlang-Compatibility-SmalltalkX' }
+WriteStream >> nextLargePut: anInteger [
+	self nextPutInt64: anInteger MSB: false.
+
+]
+
+{ #category : #'*Powerlang-Compatibility-SmalltalkX' }
 WriteStream >> nextLongPut: anInteger [
 	self nextPutInt32: anInteger MSB: false.
 

--- a/bootstrap/src/Powerlang-Core/ABI.class.st
+++ b/bootstrap/src/Powerlang-Core/ABI.class.st
@@ -5,10 +5,7 @@ Copyright (c) 2020 Aucerna.
 Class {
 	#name : #ABI,
 	#superclass : #Object,
-	#pools : [
-		'Registers'
-	],
-	#category : #'Powerlang-Core-Assembler-Intel'
+	#category : #'Powerlang-Core-Assembler'
 }
 
 { #category : #unclassified }

--- a/bootstrap/src/Powerlang-Core/AssemblerAMD64.class.st
+++ b/bootstrap/src/Powerlang-Core/AssemblerAMD64.class.st
@@ -228,8 +228,15 @@ AssemblerAMD64 >> assembleBytes: aByteArray [
 ]
 
 { #category : #basic }
-AssemblerAMD64 >> assembleBytes: aByteArray count: integer [
-	1 to: integer do: [:i | memory nextPut: (aByteArray byteAt: i)]
+AssemblerAMD64 >> assembleBytes: value count: count [
+	self ASSERT: value isInteger.
+	self ASSERT:(count == 4 or:[ count == 8 ]).
+
+	count == 4 ifTrue: [
+		memory nextLongPut: value
+	] ifFalse: [ 
+		memory nextLargePut: value
+	].
 
 ]
 

--- a/bootstrap/src/Powerlang-Core/AssemblerAMD64.class.st
+++ b/bootstrap/src/Powerlang-Core/AssemblerAMD64.class.st
@@ -3,8 +3,8 @@ Copyright (c) 2020 Aucerna.
     See (MIT) license in root directory.
 "
 Class {
-	#name : #Assembler64,
-	#superclass : #Object,
+	#name : #AssemblerAMD64,
+	#superclass : #JITAssembler,
 	#instVars : [
 		'instruction',
 		'operands1',
@@ -13,7 +13,6 @@ Class {
 		'pointer',
 		'immediate',
 		'encoder',
-		'wordSize',
 		'memory',
 		'labels'
 	],
@@ -23,11 +22,11 @@ Class {
 	#pools : [
 		'Registers'
 	],
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#category : #'Powerlang-Core-Assembler-Intel'
 }
 
 { #category : #initialization }
-Assembler64 class >> growIndexedLabelsTo: anInteger [
+AssemblerAMD64 class >> growIndexedLabelsTo: anInteger [
 	| new |
 	new := (IndexedLabels size + 1 to: anInteger)
 		collect: [:i | ('@' , i asString) asSymbol].
@@ -35,54 +34,54 @@ Assembler64 class >> growIndexedLabelsTo: anInteger [
 ]
 
 { #category : #initialization }
-Assembler64 class >> initialize [
+AssemblerAMD64 class >> initialize [
 	self initializeIndexedLabels
 	
 ]
 
 { #category : #initialization }
-Assembler64 class >> initializeIndexedLabels [
+AssemblerAMD64 class >> initializeIndexedLabels [
 	IndexedLabels := #().
 	self growIndexedLabelsTo: 100
 ]
 
 { #category : #'instance creation' }
-Assembler64 class >> new [
+AssemblerAMD64 class >> new [
 	^super new initialize
 ]
 
 { #category : #labels }
-Assembler64 >> @ label [
+AssemblerAMD64 >> @ label [
 	self addLabel: label
 ]
 
 { #category : #services }
-Assembler64 >> add: op1 to: op2 [
+AssemblerAMD64 >> add: op1 to: op2 [
 	self assemble: 'add' with: op2 with: op1
 ]
 
 { #category : #labels }
-Assembler64 >> addLabel: aString [
+AssemblerAMD64 >> addLabel: aString [
 	self addLabel: aString to: self currentAddress
 ]
 
 { #category : #labels }
-Assembler64 >> addLabel: label to: location [
+AssemblerAMD64 >> addLabel: label to: location [
 	labels at: label put: location
 ]
 
 { #category : #accessing }
-Assembler64 >> addressLength [
+AssemblerAMD64 >> addressLength [
 	^wordSize * 8
 ]
 
 { #category : #accessing }
-Assembler64 >> addressSize [
+AssemblerAMD64 >> addressSize [
 	^wordSize
 ]
 
 { #category : #alignment }
-Assembler64 >> alignTo: aNumber [
+AssemblerAMD64 >> alignTo: aNumber [
 	| current count |
 	current := memory position.
 	count := (current alignedTo: aNumber) - current.
@@ -90,33 +89,33 @@ Assembler64 >> alignTo: aNumber [
 ]
 
 { #category : #services }
-Assembler64 >> and: op1 with: op2 [
+AssemblerAMD64 >> and: op1 with: op2 [
 	self assemble: 'and' with: op1 with: op2
 ]
 
 { #category : #services }
-Assembler64 >> and: op1 withImm: op2 [
+AssemblerAMD64 >> and: op1 withImm: op2 [
 	self assemble: 'and' with: op1 withImm: op2
 ]
 
 { #category : #relocation }
-Assembler64 >> applyFixups [
+AssemblerAMD64 >> applyFixups [
 	memory applyFixupsWith: self
 ]
 
 { #category : #basic }
-Assembler64 >> assemble [
+AssemblerAMD64 >> assemble [
 	encoder reset; writeEncodingOn: memory
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic [
+AssemblerAMD64 >> assemble: mnemonic [
 	instruction mnemonic: mnemonic; operands: #().
 	self assemble
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic with: op [
+AssemblerAMD64 >> assemble: mnemonic with: op [
 	| op1 |
 	op1 := op isInteger ifTrue: [immediate value: op] ifFalse: [op].
 	operands1 at: 1 put: op1.
@@ -125,7 +124,7 @@ Assembler64 >> assemble: mnemonic with: op [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic with: op1 with: op2 [
+AssemblerAMD64 >> assemble: mnemonic with: op1 with: op2 [
 	| op |
 	op := op2 isInteger ifTrue: [immediate value: op2] ifFalse: [op2].
 	operands2
@@ -136,7 +135,7 @@ Assembler64 >> assemble: mnemonic with: op1 with: op2 [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic
+AssemblerAMD64 >> assemble: mnemonic
 with: op1
 with: op2
 with: op3 [
@@ -151,7 +150,7 @@ with: op3 [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic with: op1 withImm64: op2 [
+AssemblerAMD64 >> assemble: mnemonic with: op1 withImm64: op2 [
 	| v |
 	v := self regV.
 	self
@@ -160,7 +159,7 @@ Assembler64 >> assemble: mnemonic with: op1 withImm64: op2 [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic with: op1 withImm: imm [
+AssemblerAMD64 >> assemble: mnemonic with: op1 withImm: imm [
 	immediate value: imm.
 	(immediate length <= 32 or: [mnemonic = 'mov' and: [op1 class == Register]])
 		ifTrue: [self assemble: mnemonic with: op1 with: immediate]
@@ -168,7 +167,7 @@ Assembler64 >> assemble: mnemonic with: op1 withImm: imm [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic withImm64: op1 [
+AssemblerAMD64 >> assemble: mnemonic withImm64: op1 [
 	| v |
 	v := self regV.
 	self
@@ -177,7 +176,7 @@ Assembler64 >> assemble: mnemonic withImm64: op1 [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic withImm: imm [
+AssemblerAMD64 >> assemble: mnemonic withImm: imm [
 	immediate value: imm.
 	immediate length <= 32
 		ifTrue: [self assemble: mnemonic with: immediate]
@@ -185,7 +184,7 @@ Assembler64 >> assemble: mnemonic withImm: imm [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic withReg: reg index: index [
+AssemblerAMD64 >> assemble: mnemonic withReg: reg index: index [
 	pointer
 		reset;
 		length: self addressLength;
@@ -195,7 +194,7 @@ Assembler64 >> assemble: mnemonic withReg: reg index: index [
 ]
 
 { #category : #basic }
-Assembler64 >> assemble: mnemonic
+AssemblerAMD64 >> assemble: mnemonic
 withReg: dst
 withReg: src
 index: index [
@@ -208,7 +207,7 @@ index: index [
 ]
 
 { #category : #basic }
-Assembler64 >> assembleAddress: mem [
+AssemblerAMD64 >> assembleAddress: mem [
 	| address |
 	address := mem isInteger ifTrue: [mem] ifFalse: [
 		memory addAbsoluteFixup: mem.
@@ -219,28 +218,28 @@ Assembler64 >> assembleAddress: mem [
 ]
 
 { #category : #basic }
-Assembler64 >> assembleByte: byte [
+AssemblerAMD64 >> assembleByte: byte [
 	memory nextBytePut: byte
 ]
 
 { #category : #basic }
-Assembler64 >> assembleBytes: aByteArray [
+AssemblerAMD64 >> assembleBytes: aByteArray [
 	memory nextBytesPut: aByteArray
 ]
 
 { #category : #basic }
-Assembler64 >> assembleBytes: aByteArray count: integer [
+AssemblerAMD64 >> assembleBytes: aByteArray count: integer [
 	1 to: integer do: [:i | memory nextPut: (aByteArray byteAt: i)]
 
 ]
 
 { #category : #accessing }
-Assembler64 >> assembly [
+AssemblerAMD64 >> assembly [
 	^memory bytes
 ]
 
 { #category : #storing }
-Assembler64 >> at: position putPointer: value [
+AssemblerAMD64 >> at: position putPointer: value [
 	| original |
 	original := memory position.
 	[
@@ -252,12 +251,12 @@ Assembler64 >> at: position putPointer: value [
 ]
 
 { #category : #relocation }
-Assembler64 >> baseAddress [
+AssemblerAMD64 >> baseAddress [
 	^memory baseAddress
 ]
 
 { #category : #private }
-Assembler64 >> bitLengthOf: anInteger [
+AssemblerAMD64 >> bitLengthOf: anInteger [
 	(anInteger between: -16r80 and: 16r7F) ifTrue: [^8].
 	(anInteger between: -16r8000 and: 16r7FFF) ifTrue: [^16].
 	(anInteger between: -16r80000000 and: 16r7FFFFFFF) ifTrue: [^32].
@@ -271,65 +270,65 @@ Assembler64 >> bitLengthOf: anInteger [
 ]
 
 { #category : #debugging }
-Assembler64 >> breakpoint [
+AssemblerAMD64 >> breakpoint [
 	self assemble: 'int' with: 3
 ]
 
 { #category : #accessing }
-Assembler64 >> bytes [
+AssemblerAMD64 >> bytes [
 	^memory bytes
 ]
 
 { #category : #accessing }
-Assembler64 >> callIndirectReg: reg [
+AssemblerAMD64 >> callIndirectReg: reg [
 	pointer reset; length: reg length; base: reg.
 	self assemble: 'call' with: pointer
 ]
 
 { #category : #calls }
-Assembler64 >> callTo: label [
+AssemblerAMD64 >> callTo: label [
 	self jump: 'call' to: label size: 4
 ]
 
 { #category : #accessing }
-Assembler64 >> clearIntegerBit: op1 [
+AssemblerAMD64 >> clearIntegerBit: op1 [
 	self and: op1 with: -2
 ]
 
 { #category : #accessing }
-Assembler64 >> codeSize [
+AssemblerAMD64 >> codeSize [
 	^memory codeSize
 ]
 
 { #category : #services }
-Assembler64 >> compare: op1 with: op2 [
+AssemblerAMD64 >> compare: op1 with: op2 [
 	self assemble: 'cmp' with: op1 with: op2
 ]
 
 { #category : #integers }
-Assembler64 >> convertToNativeInteger: reg [
+AssemblerAMD64 >> convertToNativeInteger: reg [
 	self assemble: 'sar' with: reg with: 1
 ]
 
 { #category : #integers }
-Assembler64 >> convertToSmallInteger: reg [
+AssemblerAMD64 >> convertToSmallInteger: reg [
 	self
 		assemble: 'sal' with: reg with: 1;
 		assemble: 'inc' with: reg
 ]
 
 { #category : #labels }
-Assembler64 >> currentAddress [
+AssemblerAMD64 >> currentAddress [
 	^memory currentAddress
 ]
 
 { #category : #services }
-Assembler64 >> exchange: op1 with: op2 [
+AssemblerAMD64 >> exchange: op1 with: op2 [
 	self assemble: 'xchg' with: op1 with: op2
 ]
 
 { #category : #initialization }
-Assembler64 >> initialize [
+AssemblerAMD64 >> initialize [
 	super initialize.
 	instruction := ISAInstruction new.
 	operands1 := Array new: 1.
@@ -343,7 +342,7 @@ Assembler64 >> initialize [
 ]
 
 { #category : #'private - jumps' }
-Assembler64 >> jump: mnemonic to: label size: n [
+AssemblerAMD64 >> jump: mnemonic to: label size: n [
 	| placeholder end |
 	placeholder := 1 bitShift: n - 1 * 8.
 	self assemble: mnemonic with: placeholder.
@@ -357,72 +356,72 @@ Assembler64 >> jump: mnemonic to: label size: n [
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfBelowOrEqualTo: label [
+AssemblerAMD64 >> jumpIfBelowOrEqualTo: label [
 	self nearJump: 'jbe' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfEqualTo: label [
+AssemblerAMD64 >> jumpIfEqualTo: label [
 	self nearJump: 'jz' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfGreaterOrEqualSignedTo: label [
+AssemblerAMD64 >> jumpIfGreaterOrEqualSignedTo: label [
 	self nearJump: 'jge' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfGreaterSignedTo: label [
+AssemblerAMD64 >> jumpIfGreaterSignedTo: label [
 	self nearJump: 'jg' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfLessOrEqualSignedTo: label [
+AssemblerAMD64 >> jumpIfLessOrEqualSignedTo: label [
 	self nearJump: 'jle' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfLessSignedTo: label [
+AssemblerAMD64 >> jumpIfLessSignedTo: label [
 	self nearJump: 'jl' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfNotCarryTo: label [
+AssemblerAMD64 >> jumpIfNotCarryTo: label [
 	self nearJump: 'jnc' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfNotEqualTo: label [
+AssemblerAMD64 >> jumpIfNotEqualTo: label [
 	self nearJump: 'jnz' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfNotOverflowTo: label [
+AssemblerAMD64 >> jumpIfNotOverflowTo: label [
 	self nearJump: 'jno' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfNotZeroTo: label [
+AssemblerAMD64 >> jumpIfNotZeroTo: label [
 	self jumpIfNotEqualTo: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfOverflowTo: label [
+AssemblerAMD64 >> jumpIfOverflowTo: label [
 	self nearJump: 'jo' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfSignTo: label [
+AssemblerAMD64 >> jumpIfSignTo: label [
 	self nearJump: 'js' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpIfZeroTo: label [
+AssemblerAMD64 >> jumpIfZeroTo: label [
 	self jumpIfEqualTo: label
 ]
 
 { #category : #accessing }
-Assembler64 >> jumpOver: aBlock [
+AssemblerAMD64 >> jumpOver: aBlock [
 	| label |
 	label := self newLabel.
 	self jumpTo: label.
@@ -431,24 +430,24 @@ Assembler64 >> jumpOver: aBlock [
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpTo: label [
+AssemblerAMD64 >> jumpTo: label [
 	self nearJump: 'jmp' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> jumpToReg: reg [
+AssemblerAMD64 >> jumpToReg: reg [
 	self assemble: 'jmp' with: reg
 ]
 
 { #category : #integers }
-Assembler64 >> lastEmittedPointer [
+AssemblerAMD64 >> lastEmittedPointer [
 	| patch |
 	patch := self currentAddress.
 	^patch - wordSize
 ]
 
 { #category : #integers }
-Assembler64 >> leadingRzeroCount [
+AssemblerAMD64 >> leadingRzeroCount [
 	"
 	lzcnt is a special x64 extension: it puts the REX
 	prefix after the first opcode byte. Our x64 
@@ -464,7 +463,7 @@ Assembler64 >> leadingRzeroCount [
 ]
 
 { #category : #storing }
-Assembler64 >> load: reg1 from: reg2 atIndex: index [
+AssemblerAMD64 >> load: reg1 from: reg2 atIndex: index [
 	| offset |
 	offset := reg1 offsetOfIndex: index.
 	pointer
@@ -476,7 +475,7 @@ Assembler64 >> load: reg1 from: reg2 atIndex: index [
 ]
 
 { #category : #storing }
-Assembler64 >> load: reg1 from: reg2 atIndexAt: reg3 [
+AssemblerAMD64 >> load: reg1 from: reg2 atIndexAt: reg3 [
 	pointer
 		reset;
 		length: reg1 length;
@@ -488,17 +487,17 @@ Assembler64 >> load: reg1 from: reg2 atIndexAt: reg3 [
 ]
 
 { #category : #jumps }
-Assembler64 >> load: reg withImmediate: imm [
+AssemblerAMD64 >> load: reg withImmediate: imm [
 	self assemble: 'mov' with: reg with: imm
 ]
 
 { #category : #storing }
-Assembler64 >> loadZeroExtendByte: reg1 from: reg2 atIndex: index [
+AssemblerAMD64 >> loadZeroExtendByte: reg1 from: reg2 atIndex: index [
 	self loadZeroExtendByte: reg1 from: reg2 atOffset: index - 1
 ]
 
 { #category : #storing }
-Assembler64 >> loadZeroExtendByte: reg1 from: reg2 atIndexAt: reg3 [
+AssemblerAMD64 >> loadZeroExtendByte: reg1 from: reg2 atIndexAt: reg3 [
 	pointer
 		reset;
 		length: 8;
@@ -509,7 +508,7 @@ Assembler64 >> loadZeroExtendByte: reg1 from: reg2 atIndexAt: reg3 [
 ]
 
 { #category : #storing }
-Assembler64 >> loadZeroExtendByte: reg1 from: reg2 atOffset: offset [
+AssemblerAMD64 >> loadZeroExtendByte: reg1 from: reg2 atOffset: offset [
 	pointer
 		reset;
 		length: 8;
@@ -519,23 +518,23 @@ Assembler64 >> loadZeroExtendByte: reg1 from: reg2 atOffset: offset [
 ]
 
 { #category : #services }
-Assembler64 >> move: reg2 to: reg1 [
+AssemblerAMD64 >> move: reg2 to: reg1 [
 	self ASSERT: (reg2 class = Register and: [reg1 class = Register]).
 	self assemble: 'mov' with: reg1 with: reg2
 ]
 
 { #category : #'private - jumps' }
-Assembler64 >> nativeCode [
+AssemblerAMD64 >> nativeCode [
 	^ NativeCode new code: memory bytes
 ]
 
 { #category : #'private - jumps' }
-Assembler64 >> nearJump: mnemonic to: label [
+AssemblerAMD64 >> nearJump: mnemonic to: label [
 	self jump: mnemonic to: label size: 4
 ]
 
 { #category : #labels }
-Assembler64 >> newLabel [
+AssemblerAMD64 >> newLabel [
 	| label next |
 	next := labels size + 1.
 	IndexedLabels size < next ifTrue: [self class growIndexedLabelsTo: next].
@@ -545,52 +544,52 @@ Assembler64 >> newLabel [
 ]
 
 { #category : #alignment }
-Assembler64 >> nop [
+AssemblerAMD64 >> nop [
 	self assemble: 'nop'
 ]
 
 { #category : #alignment }
-Assembler64 >> nop2 [
+AssemblerAMD64 >> nop2 [
 	memory nextPutAll: #[16r66 16r90]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop3 [
+AssemblerAMD64 >> nop3 [
 	memory nextPutAll: #[16r0F 16r1F 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop4 [
+AssemblerAMD64 >> nop4 [
 	memory nextPutAll: #[16r0F 16r1F 16r40 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop5 [
+AssemblerAMD64 >> nop5 [
 	memory nextPutAll: #[16r0F 16r1F 16r44 16r00 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop6 [
+AssemblerAMD64 >> nop6 [
 	memory nextPutAll: #[16r66 16r0F 16r1F 16r44 16r00 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop7 [
+AssemblerAMD64 >> nop7 [
 	memory nextPutAll: #[16r0F 16r1F 16r80 16r00 16r00 16r00 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop8 [
+AssemblerAMD64 >> nop8 [
 	memory nextPutAll: #[16r0F 16r1F 16r84 16r00 16r00 16r00 16r00 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop9 [
+AssemblerAMD64 >> nop9 [
 	memory nextPutAll: #[16r66 16r0F 16r1F 16r84 16r00 16r00 16r00 16r00 16r00]
 ]
 
 { #category : #alignment }
-Assembler64 >> nop: count [
+AssemblerAMD64 >> nop: count [
 	"
 	ShellDLL current openWebPage: 'http://www.felixcloutier.com/x86/NOP.html'
 	"
@@ -610,33 +609,33 @@ Assembler64 >> nop: count [
 ]
 
 { #category : #calls }
-Assembler64 >> offsetOfIndex: index [
+AssemblerAMD64 >> offsetOfIndex: index [
 	^index - 1 * wordSize
 ]
 
 { #category : #services }
-Assembler64 >> or: op1 with: op2 [
+AssemblerAMD64 >> or: op1 with: op2 [
 	self assemble: 'or' with: op1 with: op2
 ]
 
 { #category : #private }
-Assembler64 >> pop: op1 [
+AssemblerAMD64 >> pop: op1 [
 	self assemble: 'pop' with: op1
 ]
 
 { #category : #private }
-Assembler64 >> printOn: aStream [
+AssemblerAMD64 >> printOn: aStream [
 	aStream print: self class; cr; cr;
 		nextPutAll: memory bytes disassembledAmd64
 ]
 
 { #category : #accessing }
-Assembler64 >> push: op1 [
+AssemblerAMD64 >> push: op1 [
 	self assemble: 'push' with: op1
 ]
 
 { #category : #storing }
-Assembler64 >> putPointer: oop at: position [
+AssemblerAMD64 >> putPointer: oop at: position [
 	| original |
 	original := memory position.
 	[
@@ -648,12 +647,12 @@ Assembler64 >> putPointer: oop at: position [
 ]
 
 { #category : #private }
-Assembler64 >> regV [
+AssemblerAMD64 >> regV [
 	^r11
 ]
 
 { #category : #relocation }
-Assembler64 >> relocateTo: address [
+AssemblerAMD64 >> relocateTo: address [
 	| delta |
 	delta := address - self baseAddress.
 	labels
@@ -664,7 +663,7 @@ Assembler64 >> relocateTo: address [
 ]
 
 { #category : #accessing }
-Assembler64 >> renameByteRegisterIfNeeded: register preserving: preserved during: aBlock [
+AssemblerAMD64 >> renameByteRegisterIfNeeded: register preserving: preserved during: aBlock [
 	self
 		renameByteRegisterIfNeeded: register
 		preserving: preserved
@@ -673,7 +672,7 @@ Assembler64 >> renameByteRegisterIfNeeded: register preserving: preserved during
 ]
 
 { #category : #accessing }
-Assembler64 >> renameByteRegisterIfNeeded: register
+AssemblerAMD64 >> renameByteRegisterIfNeeded: register
 preserving: preserved1
 preserving: preserved2
 during: aBlock [
@@ -688,7 +687,7 @@ during: aBlock [
 ]
 
 { #category : #accessing }
-Assembler64 >> renameRegisterPreserving: preserved1 preserving: preserved2 [
+AssemblerAMD64 >> renameRegisterPreserving: preserved1 preserving: preserved2 [
 	preserved1 == self regR
 		ifTrue: [preserved2 == self regA
 			ifTrue: [^self regT]
@@ -701,119 +700,119 @@ Assembler64 >> renameRegisterPreserving: preserved1 preserving: preserved2 [
 ]
 
 { #category : #initialization }
-Assembler64 >> reset [
+AssemblerAMD64 >> reset [
 	labels := Dictionary new: 100.
 	memory reset
 ]
 
 { #category : #labels }
-Assembler64 >> resolveLabel: aString [
+AssemblerAMD64 >> resolveLabel: aString [
 	^labels at: aString ifAbsent: [self addressOfExternal: aString]
 ]
 
 { #category : #calls }
-Assembler64 >> return [
+AssemblerAMD64 >> return [
 	self assemble: 'ret'
 ]
 
 { #category : #calls }
-Assembler64 >> return: anInteger [
+AssemblerAMD64 >> return: anInteger [
 	anInteger = 0
 		ifTrue: [self assemble: 'ret']
 		ifFalse: [self assemble: 'ret' with: anInteger * self addressSize]
 ]
 
 { #category : #accessing }
-Assembler64 >> rotateLeft: op1 count: count [
+AssemblerAMD64 >> rotateLeft: op1 count: count [
 	self ASSERT: count < 32.
 	self assemble: 'rol' with: op1 with: count
 ]
 
 { #category : #accessing }
-Assembler64 >> rotateRight: op1 count: count [
+AssemblerAMD64 >> rotateRight: op1 count: count [
 	self ASSERT: count < 32.
 	self assemble: 'ror' with: op1 with: count
 ]
 
 { #category : #accessing }
-Assembler64 >> setIntegerBit: op1 [
+AssemblerAMD64 >> setIntegerBit: op1 [
 	self assemble: 'or' with: op1 with: 1
 ]
 
 { #category : #accessing }
-Assembler64 >> shiftLeft: op1 by: count [
+AssemblerAMD64 >> shiftLeft: op1 by: count [
 	self ASSERT: count < 32.
 	self assemble: 'sal' with: op1 with: count
 ]
 
 { #category : #accessing }
-Assembler64 >> shiftRight: op1 by: op2 [
+AssemblerAMD64 >> shiftRight: op1 by: op2 [
 	self ASSERT: (op2 isInteger not or: [op2 < op1 length]).
 	self assemble: 'sar' with: op1 with: op2
 ]
 
 { #category : #'private - jumps' }
-Assembler64 >> shortJump: mnemonic to: label [
+AssemblerAMD64 >> shortJump: mnemonic to: label [
 	self jump: mnemonic to: label size: 1
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfCarryTo: label [
+AssemblerAMD64 >> shortJumpIfCarryTo: label [
 	self shortJump: 'jc' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfEqualTo: label [
+AssemblerAMD64 >> shortJumpIfEqualTo: label [
 	self shortJump: 'jz' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfLessOrEqualSignedTo: label [
+AssemblerAMD64 >> shortJumpIfLessOrEqualSignedTo: label [
 	self shortJump: 'jle' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfLessSignedTo: label [
+AssemblerAMD64 >> shortJumpIfLessSignedTo: label [
 	self shortJump: 'jl' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfNotCarryTo: label [
+AssemblerAMD64 >> shortJumpIfNotCarryTo: label [
 	self shortJump: 'jnc' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfNotEqualTo: label [
+AssemblerAMD64 >> shortJumpIfNotEqualTo: label [
 	self shortJump: 'jnz' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfNotOverflowTo: label [
+AssemblerAMD64 >> shortJumpIfNotOverflowTo: label [
 	self shortJump: 'jno' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfNotZeroTo: label [
+AssemblerAMD64 >> shortJumpIfNotZeroTo: label [
 	self shortJumpIfNotEqualTo: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfOverflowTo: label [
+AssemblerAMD64 >> shortJumpIfOverflowTo: label [
 	self shortJump: 'jo' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfSignTo: label [
+AssemblerAMD64 >> shortJumpIfSignTo: label [
 	self shortJump: 'js' to: label
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpIfZeroTo: label [
+AssemblerAMD64 >> shortJumpIfZeroTo: label [
 	self shortJumpIfEqualTo: label
 ]
 
 { #category : #accessing }
-Assembler64 >> shortJumpOver: aBlock [
+AssemblerAMD64 >> shortJumpOver: aBlock [
 	| label |
 	label := self newLabel.
 	self shortJumpTo: label.
@@ -822,12 +821,12 @@ Assembler64 >> shortJumpOver: aBlock [
 ]
 
 { #category : #jumps }
-Assembler64 >> shortJumpTo: label [
+AssemblerAMD64 >> shortJumpTo: label [
 	self shortJump: 'jmp' to: label
 ]
 
 { #category : #storing }
-Assembler64 >> store: reg1 in: reg2 index: index [
+AssemblerAMD64 >> store: reg1 in: reg2 index: index [
 	| offset |
 	offset := reg1 offsetOfIndex: index.
 	pointer
@@ -839,7 +838,7 @@ Assembler64 >> store: reg1 in: reg2 index: index [
 ]
 
 { #category : #storing }
-Assembler64 >> store: op1 in: reg2 indexAt: reg3 [
+AssemblerAMD64 >> store: op1 in: reg2 indexAt: reg3 [
 	pointer
 		reset;
 		length: op1 length;
@@ -851,12 +850,12 @@ Assembler64 >> store: op1 in: reg2 indexAt: reg3 [
 ]
 
 { #category : #storing }
-Assembler64 >> storeByte: value in: reg2 index: index [
+AssemblerAMD64 >> storeByte: value in: reg2 index: index [
 	self storeByte: value in: reg2 offset: index - 1
 ]
 
 { #category : #storing }
-Assembler64 >> storeByte: byte in: reg2 offset: offset [
+AssemblerAMD64 >> storeByte: byte in: reg2 offset: offset [
 	pointer
 		reset;
 		length: 8;
@@ -866,17 +865,17 @@ Assembler64 >> storeByte: byte in: reg2 offset: offset [
 ]
 
 { #category : #initialization }
-Assembler64 >> stream [
+AssemblerAMD64 >> stream [
 	^memory stream
 ]
 
 { #category : #services }
-Assembler64 >> subtract: op1 from: op2 [
+AssemblerAMD64 >> subtract: op1 from: op2 [
 	self assemble: 'sub' with: op2 with: op1
 ]
 
 { #category : #services }
-Assembler64 >> testIntegerBit: op1 [
+AssemblerAMD64 >> testIntegerBit: op1 [
 	| op |
 	op := op1 byte.
 	(self addressSize = 4 and: [op isLongModeOld8BitRegister])
@@ -885,12 +884,12 @@ Assembler64 >> testIntegerBit: op1 [
 ]
 
 { #category : #accessing }
-Assembler64 >> wordSize: anInteger [
+AssemblerAMD64 >> wordSize: anInteger [
 	wordSize := anInteger.
 	encoder wordSize: anInteger
 ]
 
 { #category : #accessing }
-Assembler64 >> wordSizeShift [
+AssemblerAMD64 >> wordSizeShift [
 	^wordSize = 8 ifTrue: [3] ifFalse: [2]
 ]

--- a/bootstrap/src/Powerlang-Core/JITAssembler.class.st
+++ b/bootstrap/src/Powerlang-Core/JITAssembler.class.st
@@ -1,0 +1,8 @@
+Class {
+	#name : #JITAssembler,
+	#superclass : #Object,
+	#instVars : [
+		'wordSize'
+	],
+	#category : #'Powerlang-Core-Assembler'
+}

--- a/bootstrap/src/Powerlang-Core/JITAssemblerAMD64.class.st
+++ b/bootstrap/src/Powerlang-Core/JITAssemblerAMD64.class.st
@@ -3,40 +3,40 @@ Copyright (c) 2020 Aucerna.
     See (MIT) license in root directory.
 "
 Class {
-	#name : #JITAssembler64,
-	#superclass : #Assembler64,
+	#name : #JITAssemblerAMD64,
+	#superclass : #AssemblerAMD64,
 	#instVars : [
 		'literals'
 	],
 	#classVars : [
 		'ExternalFunctions'
 	],
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#category : #'Powerlang-Core-Assembler-Intel'
 }
 
 { #category : #inspecting }
-JITAssembler64 class >> aspects [
+JITAssemblerAMD64 class >> aspects [
 	^#(#disassembledText32 #disassembledText64)
 ]
 
 { #category : #initialization }
-JITAssembler64 class >> initialize [
+JITAssemblerAMD64 class >> initialize [
 	super initialize.
 	ExternalFunctions := Dictionary new
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addAtoR [
+JITAssemblerAMD64 >> addAtoR [
 	self assemble: 'add' with: self regR with: self regA
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addDoubleX1toX0 [
+JITAssemblerAMD64 >> addDoubleX1toX0 [
 	self assemble: 'addsd' with: xmm0 with: xmm1
 ]
 
 { #category : #loading }
-JITAssembler64 >> addLiteral: anObject [
+JITAssemblerAMD64 >> addLiteral: anObject [
 	| index | 
 	index := literals
 		indexOf: anObject
@@ -47,24 +47,24 @@ JITAssembler64 >> addLiteral: anObject [
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addRconstant: imm [
+JITAssemblerAMD64 >> addRconstant: imm [
 	self assemble: 'add' with: self regR withImm: imm
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addSPtoT [
+JITAssemblerAMD64 >> addSPtoT [
 	self assemble: 'add' with: self regT with: self regSP
 ]
 
 { #category : #logic }
-JITAssembler64 >> addSPwithImmediate: imm [
+JITAssemblerAMD64 >> addSPwithImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'add' with: self regSP withImm: imm
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addSslotsToSP [
+JITAssemblerAMD64 >> addSslotsToSP [
 	pointer
 		reset;
 		length: self addressLength;
@@ -75,12 +75,12 @@ JITAssembler64 >> addSslotsToSP [
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addToTconstant: imm [
+JITAssemblerAMD64 >> addToTconstant: imm [
 	self assemble: 'add' with: self regT withImm: imm
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addTslotsToSP [
+JITAssemblerAMD64 >> addTslotsToSP [
 	pointer
 		reset;
 		length: self addressLength;
@@ -91,29 +91,29 @@ JITAssembler64 >> addTslotsToSP [
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> addTtoR [
+JITAssemblerAMD64 >> addTtoR [
 	self assemble: 'add' with: self regR with: self regT
 ]
 
 { #category : #services }
-JITAssembler64 >> addressOfExternal: function [
+JITAssemblerAMD64 >> addressOfExternal: function [
 	^ExternalFunctions at: function ifAbsent: nil
 ]
 
 { #category : #logic }
-JITAssembler64 >> andRwithA [
+JITAssemblerAMD64 >> andRwithA [
 	self assemble: 'and' with: self regR with: self regA
 ]
 
 { #category : #logic }
-JITAssembler64 >> andRwithImmediate: imm [
+JITAssemblerAMD64 >> andRwithImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'and' with: self regR withImm: imm
 ]
 
 { #category : #logic }
-JITAssembler64 >> andTosWithImmediate: anInteger [
+JITAssemblerAMD64 >> andTosWithImmediate: anInteger [
 	#imm8.
 	#imm32.
 	pointer reset; length: self addressLength; base: self regSP.
@@ -121,69 +121,69 @@ JITAssembler64 >> andTosWithImmediate: anInteger [
 ]
 
 { #category : #private }
-JITAssembler64 >> buildFrame [
+JITAssemblerAMD64 >> buildFrame [
 	self
 		push: self regFP;
 		move: self regSP to: self regFP
 ]
 
 { #category : #private }
-JITAssembler64 >> callA [
+JITAssemblerAMD64 >> callA [
 	self assemble: 'call' with: self regA
 ]
 
 { #category : #private }
-JITAssembler64 >> callIndirectA [
+JITAssemblerAMD64 >> callIndirectA [
 	pointer reset; length: self addressLength; base: self regA.
 	self assemble: 'call' with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> callIndirectM [
+JITAssemblerAMD64 >> callIndirectM [
 	pointer reset; length: self addressLength; base: self regM.
 	self assemble: 'call' with: pointer
 ]
 
 { #category : #private }
-JITAssembler64 >> callR [
+JITAssemblerAMD64 >> callR [
 	self assemble: 'call' with: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> clearAintegerBit [
+JITAssemblerAMD64 >> clearAintegerBit [
 	self assemble: 'dec' with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> clearFPUFlags [
+JITAssemblerAMD64 >> clearFPUFlags [
 	self assemble: 'fnclex'
 ]
 
 { #category : #integers }
-JITAssembler64 >> clearRhighHalf [
+JITAssemblerAMD64 >> clearRhighHalf [
 	self assemble: 'mov' with: self regR e with: self regR e
 ]
 
 { #category : #integers }
-JITAssembler64 >> clearRintegerBit [
+JITAssemblerAMD64 >> clearRintegerBit [
 	self assemble: 'dec' with: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> clearSafeRintegerBit [
+JITAssemblerAMD64 >> clearSafeRintegerBit [
 	immediate value: 16rFE; length: 8.
 	self assemble: 'and' with: al with: immediate
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compare: register withBoolean: aBoolean [
+JITAssemblerAMD64 >> compare: register withBoolean: aBoolean [
 	aBoolean
 		ifTrue: [ self compareWithTrue: register ]
 		ifFalse: [ self compareWithFalse: register ]
 ]
 
 { #category : #loading }
-JITAssembler64 >> compare: register withLiteral: anObject [
+JITAssemblerAMD64 >> compare: register withLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self
@@ -194,175 +194,175 @@ JITAssembler64 >> compare: register withLiteral: anObject [
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareAwithBoolean: aBoolean [
+JITAssemblerAMD64 >> compareAwithBoolean: aBoolean [
 	aBoolean
 		ifTrue: [ self compareAwithTrue ]
 		ifFalse: [ self compareAwithFalse ]
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareAwithFalse [
+JITAssemblerAMD64 >> compareAwithFalse [
 	self assemble: 'cmp' with: self regA with: self regFalse
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareAwithImmediate: imm [
+JITAssemblerAMD64 >> compareAwithImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'cmp' with: self regA withImm: imm
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareAwithSmallInteger: anInteger [
+JITAssemblerAMD64 >> compareAwithSmallInteger: anInteger [
 	self compareAwithImmediate: (anInteger bitShift: 1) + 1
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareAwithTrue [
+JITAssemblerAMD64 >> compareAwithTrue [
 	self assemble: 'cmp' with: self regA with: self regTrue
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareEqualLargeX0withAindirect [
+JITAssemblerAMD64 >> compareEqualLargeX0withAindirect [
 	pointer reset; length: 64; base: self regA.
 	self assemble: 'cmpsd' with: xmm0 with: pointer with: 0
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareLessThanLargeX0withAindirect [
+JITAssemblerAMD64 >> compareLessThanLargeX0withAindirect [
 	pointer reset; length: 64; base: self regA.
 	self assemble: 'cmpsd' with: xmm0 with: pointer with: 1
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithA [
+JITAssemblerAMD64 >> compareRwithA [
 	self assemble: 'cmp' with: self regR with: self regA
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithBoolean: aBoolean [
+JITAssemblerAMD64 >> compareRwithBoolean: aBoolean [
 	aBoolean
 		ifTrue: [ self compareRwithTrue ]
 		ifFalse: [ self compareRwithFalse ]
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareRwithEindex: index [
+JITAssemblerAMD64 >> compareRwithEindex: index [
 	self assemble: 'cmp' withReg: self regR withReg: self regE index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareRwithFPindex: index [
+JITAssemblerAMD64 >> compareRwithFPindex: index [
 	self assemble: 'cmp' withReg: self regR withReg: self regFP index: index
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithFalse [
+JITAssemblerAMD64 >> compareRwithFalse [
 	self assemble: 'cmp' with: self regR with: self regFalse
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithImmediate: imm [
+JITAssemblerAMD64 >> compareRwithImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'cmp' with: self regR withImm: imm
 ]
 
 { #category : #storing }
-JITAssembler64 >> compareRwithIndirect: reg1 andExchange: reg2 [
+JITAssemblerAMD64 >> compareRwithIndirect: reg1 andExchange: reg2 [
 	pointer reset; length: self addressLength; base: reg1.
 	self assemble: 'cmpxchg' with: pointer with: reg2
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithNil [
+JITAssemblerAMD64 >> compareRwithNil [
 	self assemble: 'cmp' with: self regR with: self regNil
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithS [
+JITAssemblerAMD64 >> compareRwithS [
 	self assemble: 'cmp' with: self regR with: self regS
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareRwithSindex: index [
+JITAssemblerAMD64 >> compareRwithSindex: index [
 	self assemble: 'cmp' withReg: self regR withReg: self regS index: index
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithSmallInteger: anInteger [
+JITAssemblerAMD64 >> compareRwithSmallInteger: anInteger [
 	self compareRwithImmediate: (anInteger bitShift: 1) + 1
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareRwithTrue [
+JITAssemblerAMD64 >> compareRwithTrue [
 	self assemble: 'cmp' with: self regR with: self regTrue
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareRwithVindex: index [
+JITAssemblerAMD64 >> compareRwithVindex: index [
 	self assemble: 'cmp' withReg: self regR withReg: self regV index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareSwithTindex: index [
+JITAssemblerAMD64 >> compareSwithTindex: index [
 	self assemble: 'cmp' withReg: self regS withReg: self regT index: index
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareTwithA [
+JITAssemblerAMD64 >> compareTwithA [
 	self assemble: 'cmp' with: self regT with: self regA
 ]
 
 { #category : #comparing }
-JITAssembler64 >> compareTwithImmediate: imm [
+JITAssemblerAMD64 >> compareTwithImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'cmp' with: self regT withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareWithFalse: register [
+JITAssemblerAMD64 >> compareWithFalse: register [
 	self assemble: 'cmp' with: register with: self regFalse
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareWithNil: register [
+JITAssemblerAMD64 >> compareWithNil: register [
 	self assemble: 'cmp' with: register with: self regNil
 ]
 
 { #category : #loading }
-JITAssembler64 >> compareWithTrue: register [
+JITAssemblerAMD64 >> compareWithTrue: register [
 	self assemble: 'cmp' with: register with: self regTrue
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertAtoNativeInteger [
+JITAssemblerAMD64 >> convertAtoNativeInteger [
 	self convertToNativeInteger: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertAtoSmallInteger [
+JITAssemblerAMD64 >> convertAtoSmallInteger [
 	self convertToSmallInteger: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertRtoNativeInteger [
+JITAssemblerAMD64 >> convertRtoNativeInteger [
 	self convertToNativeInteger: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertRtoSmallInteger [
+JITAssemblerAMD64 >> convertRtoSmallInteger [
 	self convertToSmallInteger: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertTToNativeInteger [
+JITAssemblerAMD64 >> convertTToNativeInteger [
 	self convertToNativeInteger: self regT
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertTosToSmallInteger [
+JITAssemblerAMD64 >> convertTosToSmallInteger [
 	pointer reset; length: self addressLength; base: self regSP.
 	self
 		assemble: 'shl' with: pointer with: 1;
@@ -370,49 +370,49 @@ JITAssembler64 >> convertTosToSmallInteger [
 ]
 
 { #category : #integers }
-JITAssembler64 >> convertTtoNativeInteger [
+JITAssemblerAMD64 >> convertTtoNativeInteger [
 	self convertToNativeInteger: self regT
 ]
 
 { #category : #jumps }
-JITAssembler64 >> dec: op1 [
+JITAssemblerAMD64 >> dec: op1 [
 	self assemble: 'dec' with: op1
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> decR [
+JITAssemblerAMD64 >> decR [
 	self assemble: 'dec' with: self regR
 ]
 
 { #category : #private }
-JITAssembler64 >> decRindirect [
+JITAssemblerAMD64 >> decRindirect [
 	pointer reset; length: self addressLength; base: self regR.
 	self assemble: 'dec' with: pointer
 ]
 
 { #category : #services }
-JITAssembler64 >> disassembledText32 [
+JITAssemblerAMD64 >> disassembledText32 [
 	^self nativeCode disassembledText32
 ]
 
 { #category : #services }
-JITAssembler64 >> disassembledText64 [
+JITAssemblerAMD64 >> disassembledText64 [
 	^self nativeCode disassembledText64
 ]
 
 { #category : #private }
-JITAssembler64 >> discardArguments: anInteger [
+JITAssemblerAMD64 >> discardArguments: anInteger [
 	anInteger = 0 ifTrue: [^self].
 	self addSPwithImmediate: anInteger * wordSize
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> divideDoubleX0byX1 [
+JITAssemblerAMD64 >> divideDoubleX0byX1 [
 	self assemble: 'divsd' with: xmm0 with: xmm1
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> divideRbyT [
+JITAssemblerAMD64 >> divideRbyT [
 	| conversion |
 	self ASSERT: (self regR r == rax and: [self regA r == rdx]).
 	conversion := wordSize = 8 ifTrue: ['cqo'] ifFalse: ['cdq'].
@@ -422,7 +422,7 @@ JITAssembler64 >> divideRbyT [
 ]
 
 { #category : #loading }
-JITAssembler64 >> dropTopOfFPU [
+JITAssemblerAMD64 >> dropTopOfFPU [
 	"
 	fstp st(0)
 	"
@@ -430,83 +430,83 @@ JITAssembler64 >> dropTopOfFPU [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> dropTos: count [
+JITAssemblerAMD64 >> dropTos: count [
 	| imm |
 	imm := count * self addressSize.
 	self assemble: 'add' with: self regSP with: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> dummyPointer [
+JITAssemblerAMD64 >> dummyPointer [
 	#dontOptimize.
 	^wordSize = 8 ifTrue: [16r1BADADD01BADADD0] ifFalse: [16r1BADADD0]
 ]
 
 { #category : #integers }
-JITAssembler64 >> ensureRintegerBit [
+JITAssemblerAMD64 >> ensureRintegerBit [
 	self assemble: 'or' with: al with: 1
 ]
 
 { #category : #integers }
-JITAssembler64 >> ensureSafeRintegerBit [
+JITAssemblerAMD64 >> ensureSafeRintegerBit [
 	self assemble: 'or' with: al with: 1
 ]
 
 { #category : #loading }
-JITAssembler64 >> exchangeRindirectWithT [
+JITAssemblerAMD64 >> exchangeRindirectWithT [
 	pointer reset; length: self addressLength; base: self regR.
 	self assemble: 'xchg' with: pointer with: self regT
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> incA [
+JITAssemblerAMD64 >> incA [
 	self assemble: 'inc' with: self regA
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> incC [
+JITAssemblerAMD64 >> incC [
 	self assemble: 'inc' with: self regC
 ]
 
 { #category : #private }
-JITAssembler64 >> initialize [
+JITAssemblerAMD64 >> initialize [
 	super initialize.
 	literals := OrderedCollection new
 ]
 
 { #category : #private }
-JITAssembler64 >> initializeS [
+JITAssemblerAMD64 >> initializeS [
 	self assemble: 'mov' with: self regS with: self regR
 ]
 
 { #category : #private }
-JITAssembler64 >> jumpIndirectA [
+JITAssemblerAMD64 >> jumpIndirectA [
 	pointer reset; length: self addressLength; base: self regA.
 	self assemble: 'jmp' with: pointer
 ]
 
 { #category : #comparing }
-JITAssembler64 >> jumpToA [
+JITAssemblerAMD64 >> jumpToA [
 	self assemble: 'jmp' with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> jumpToMindex: index [
+JITAssemblerAMD64 >> jumpToMindex: index [
 	self assemble: 'jmp' withReg: self regM index: index
 ]
 
 { #category : #comparing }
-JITAssembler64 >> jumpToS [
+JITAssemblerAMD64 >> jumpToS [
 	self assemble: 'jmp' with: self regS
 ]
 
 { #category : #loading }
-JITAssembler64 >> jumpToTindex: index [
+JITAssemblerAMD64 >> jumpToTindex: index [
 	self assemble: 'jmp' withReg: self regT index: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerBitTestOf: aRegister [
+JITAssemblerAMD64 >> labeledIntegerBitTestOf: aRegister [
 	| label |
 	self testIntegerBitOf: aRegister.
 	label := self newLabel.
@@ -515,22 +515,22 @@ JITAssembler64 >> labeledIntegerBitTestOf: aRegister [
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerBitTestOfA [
+JITAssemblerAMD64 >> labeledIntegerBitTestOfA [
 	^self labeledIntegerBitTestOf: self regA8
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerBitTestOfR [
+JITAssemblerAMD64 >> labeledIntegerBitTestOfR [
 	^self labeledIntegerBitTestOf: self regR8
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerBitTestOfT [
+JITAssemblerAMD64 >> labeledIntegerBitTestOfT [
 	^self labeledIntegerBitTestOf: self regT byte
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerNativizationOf: aRegister [
+JITAssemblerAMD64 >> labeledIntegerNativizationOf: aRegister [
 	| label |
 	self convertToNativeInteger: aRegister.
 	label := self newLabel.
@@ -539,22 +539,22 @@ JITAssembler64 >> labeledIntegerNativizationOf: aRegister [
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerNativizationOfA [
+JITAssemblerAMD64 >> labeledIntegerNativizationOfA [
 	^self labeledIntegerNativizationOf: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerNativizationOfR [
+JITAssemblerAMD64 >> labeledIntegerNativizationOfR [
 	^self labeledIntegerNativizationOf: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledIntegerNativizationOfT [
+JITAssemblerAMD64 >> labeledIntegerNativizationOfT [
 	^self labeledIntegerNativizationOf: self regT
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledNonIntegerBitTestOf: aRegister [
+JITAssemblerAMD64 >> labeledNonIntegerBitTestOf: aRegister [
 	| label |
 	self testIntegerBitOf: aRegister.
 	label := self newLabel.
@@ -563,12 +563,12 @@ JITAssembler64 >> labeledNonIntegerBitTestOf: aRegister [
 ]
 
 { #category : #integers }
-JITAssembler64 >> labeledNonIntegerBitTestOfR [
+JITAssemblerAMD64 >> labeledNonIntegerBitTestOfR [
 	^self labeledNonIntegerBitTestOf: self regR8
 ]
 
 { #category : #loading }
-JITAssembler64 >> load: register withLiteral: anObject [
+JITAssemblerAMD64 >> load: register withLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self
@@ -579,34 +579,34 @@ JITAssembler64 >> load: register withLiteral: anObject [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithAindex: index [
+JITAssemblerAMD64 >> loadAwithAindex: index [
 	self assemble: 'mov' withReg: self regA withReg: self regA index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithBoolean: aBoolean [
+JITAssemblerAMD64 >> loadAwithBoolean: aBoolean [
 	aBoolean ifTrue: [self loadAwithTrue]
 	ifFalse: [self loadAwithFalse]
 
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithEindex: index [
+JITAssemblerAMD64 >> loadAwithEindex: index [
 	self assemble: 'mov' withReg: self regA withReg: self regE index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithFPindex: index [
+JITAssemblerAMD64 >> loadAwithFPindex: index [
 	self assemble: 'mov' withReg: self regA withReg: self regFP index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithFalse [
+JITAssemblerAMD64 >> loadAwithFalse [
 	self assemble: 'mov' with: self regA with: self regFalse
 ]
 
 { #category : #private }
-JITAssembler64 >> loadAwithGindex: index [
+JITAssemblerAMD64 >> loadAwithGindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regA
@@ -615,32 +615,32 @@ JITAssembler64 >> loadAwithGindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithGlobal: aSymbol [
+JITAssemblerAMD64 >> loadAwithGlobal: aSymbol [
 	| index |
 	index := NativizationEnvironment indexOfGlobal: aSymbol.
 	self loadAwithGindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithImmediate: imm [
+JITAssemblerAMD64 >> loadAwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regA withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithKnown: anObject [
+JITAssemblerAMD64 >> loadAwithKnown: anObject [
 	self breakpoint
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithLiteral: anObject [
+JITAssemblerAMD64 >> loadAwithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadAwithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithMindex: index [
+JITAssemblerAMD64 >> loadAwithMindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regA
@@ -649,22 +649,22 @@ JITAssembler64 >> loadAwithMindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithNil [
+JITAssemblerAMD64 >> loadAwithNil [
 	self assemble: 'mov' with: self regA with: self regNil
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithR [
+JITAssemblerAMD64 >> loadAwithR [
 	self assemble: 'mov' with: self regA with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithRindex: index [
+JITAssemblerAMD64 >> loadAwithRindex: index [
 	self assemble: 'mov' withReg: self regA withReg: self regR index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithRoffsetAtA [
+JITAssemblerAMD64 >> loadAwithRoffsetAtA [
 	pointer
 		reset;
 		length: self addressLength;
@@ -674,32 +674,32 @@ JITAssembler64 >> loadAwithRoffsetAtA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithS [
+JITAssemblerAMD64 >> loadAwithS [
 	self assemble: 'mov' with: self regA with: self regS
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithSindex: index [
+JITAssemblerAMD64 >> loadAwithSindex: index [
 	self assemble: 'mov' withReg: self regA withReg: self regS index: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadAwithSmallInteger: anInteger [
+JITAssemblerAMD64 >> loadAwithSmallInteger: anInteger [
 	self loadAwithImmediate: (anInteger bitShift: 1) + 1
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithT [
+JITAssemblerAMD64 >> loadAwithT [
 	self assemble: 'mov' with: self regA with: self regT
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadAwithTrue [
+JITAssemblerAMD64 >> loadAwithTrue [
 	self assemble: 'mov' with: self regA with: self regTrue
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadEwithAddressOfRatA [
+JITAssemblerAMD64 >> loadEwithAddressOfRatA [
 	pointer
 		reset;
 		length: self addressLength;
@@ -711,74 +711,74 @@ JITAssembler64 >> loadEwithAddressOfRatA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadEwithFPindex: index [
+JITAssemblerAMD64 >> loadEwithFPindex: index [
 	self assemble: 'mov' withReg: self regE withReg: self regFP index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadEwithImmediate: imm [
+JITAssemblerAMD64 >> loadEwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regE withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadEwithNil [
+JITAssemblerAMD64 >> loadEwithNil [
 	self assemble: 'mov' with: self regE with: self regNil
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadEwithR [
+JITAssemblerAMD64 >> loadEwithR [
 	self assemble: 'mov' with: self regE with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadFPwithR [
+JITAssemblerAMD64 >> loadFPwithR [
 	self assemble: 'mov' with: self regFP with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadFPwithSP [
+JITAssemblerAMD64 >> loadFPwithSP [
 	self assemble: 'mov' with: self regFP with: self regSP
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadFalseWithLiteral: anObject [
+JITAssemblerAMD64 >> loadFalseWithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadFalseWithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadFalseWithMindex: index [
+JITAssemblerAMD64 >> loadFalseWithMindex: index [
 	self assemble: 'mov' withReg: self regFalse withReg: self regM index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadGwithLiteral: anObject [
+JITAssemblerAMD64 >> loadGwithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadGwithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadGwithMindex: index [
+JITAssemblerAMD64 >> loadGwithMindex: index [
 	self assemble: 'mov' withReg: self regG withReg: self regM index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLargeX0withRindirect [
+JITAssemblerAMD64 >> loadLargeX0withRindirect [
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'movq' with: xmm0 with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLargeX1withAindirect [
+JITAssemblerAMD64 >> loadLargeX1withAindirect [
 	pointer reset; length: 64; base: self regA.
 	self assemble: 'movq' with: xmm1 with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLongMwithIPoffset: anInteger [
+JITAssemblerAMD64 >> loadLongMwithIPoffset: anInteger [
 	| instsize |
 	#dontOptimize.
 	instsize := 6.
@@ -791,7 +791,7 @@ JITAssembler64 >> loadLongMwithIPoffset: anInteger [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLongRWithRAtOffsetA [
+JITAssemblerAMD64 >> loadLongRWithRAtOffsetA [
 	pointer
 		reset;
 		length: 32;
@@ -801,7 +801,7 @@ JITAssembler64 >> loadLongRWithRAtOffsetA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLongRwithRatOffsetA [
+JITAssemblerAMD64 >> loadLongRwithRatOffsetA [
 	pointer
 		reset;
 		length: 32;
@@ -811,7 +811,7 @@ JITAssembler64 >> loadLongRwithRatOffsetA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadLongSwithRindex: index [
+JITAssemblerAMD64 >> loadLongSwithRindex: index [
 	#dontOptimize.
 	pointer
 		reset;
@@ -822,18 +822,18 @@ JITAssembler64 >> loadLongSwithRindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMXCSRfromA [
+JITAssemblerAMD64 >> loadMXCSRfromA [
 	pointer reset; length: 32; base: self regA.
 	self assemble: 'ldmxcsr' with: pointer
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> loadMwithA [
+JITAssemblerAMD64 >> loadMwithA [
 	self assemble: 'mov' with: self regM with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithFPindex: index [
+JITAssemblerAMD64 >> loadMwithFPindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regM
@@ -842,32 +842,32 @@ JITAssembler64 >> loadMwithFPindex: index [
 ]
 
 { #category : #private }
-JITAssembler64 >> loadMwithGindex: index [
+JITAssemblerAMD64 >> loadMwithGindex: index [
 	self assemble: 'mov' withReg: self regM withReg: self regG index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithGlobal: aSymbol [
+JITAssemblerAMD64 >> loadMwithGlobal: aSymbol [
 	| index |
 	index := NativizationEnvironment indexOfGlobal: aSymbol.
 	self loadMwithGindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithImmediate: imm [
+JITAssemblerAMD64 >> loadMwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regM withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithLiteral: anObject [
+JITAssemblerAMD64 >> loadMwithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadMwithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithMindex: index [
+JITAssemblerAMD64 >> loadMwithMindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regM
@@ -876,7 +876,7 @@ JITAssembler64 >> loadMwithMindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithRIPoffset: imm [
+JITAssemblerAMD64 >> loadMwithRIPoffset: imm [
 	pointer
 		reset;
 		length: self addressLength;
@@ -887,7 +887,7 @@ JITAssembler64 >> loadMwithRIPoffset: imm [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithRindex: index [
+JITAssemblerAMD64 >> loadMwithRindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regM
@@ -896,41 +896,41 @@ JITAssembler64 >> loadMwithRindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadMwithTindex: index [
+JITAssemblerAMD64 >> loadMwithTindex: index [
 	self assemble: 'mov' withReg: self regM withReg: self regT index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadNilWithLiteral: anObject [
+JITAssemblerAMD64 >> loadNilWithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadNilWithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadNilWithMindex: index [
+JITAssemblerAMD64 >> loadNilWithMindex: index [
 	self assemble: 'mov' withReg: self regNil withReg: self regM index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRConvertingDoubleRindirect [
+JITAssemblerAMD64 >> loadRConvertingDoubleRindirect [
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'cvttsd2si' with: self regR with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRconvertingDoublePointedByR [
+JITAssemblerAMD64 >> loadRconvertingDoublePointedByR [
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'cvttsd2si' with: self regR with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithA [
+JITAssemblerAMD64 >> loadRwithA [
 	self assemble: 'mov' with: self regR with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithArgPointer [
+JITAssemblerAMD64 >> loadRwithArgPointer [
 	pointer
 		reset;
 		length: self addressLength;
@@ -940,57 +940,57 @@ JITAssembler64 >> loadRwithArgPointer [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithBoolean: aBoolean [
+JITAssemblerAMD64 >> loadRwithBoolean: aBoolean [
 	aBoolean
 		ifTrue: [ self loadRwithTrue ]
 		ifFalse: [ self loadRwithFalse ]
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithE [
+JITAssemblerAMD64 >> loadRwithE [
 	self assemble: 'mov' with: self regR with: self regE
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithEindex: index [
+JITAssemblerAMD64 >> loadRwithEindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regE index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithFP [
+JITAssemblerAMD64 >> loadRwithFP [
 	self assemble: 'mov' with: self regR with: self regFP
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithFPindex: index [
+JITAssemblerAMD64 >> loadRwithFPindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regFP index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithFalse [
+JITAssemblerAMD64 >> loadRwithFalse [
 	self assemble: 'mov' with: self regR with: self regFalse
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithImmediate: imm [
+JITAssemblerAMD64 >> loadRwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regR withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithLiteral: anObject [
+JITAssemblerAMD64 >> loadRwithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadRwithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithM [
+JITAssemblerAMD64 >> loadRwithM [
 	self assemble: 'mov' with: self regR with: self regM
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithMindex: index [
+JITAssemblerAMD64 >> loadRwithMindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regR
@@ -999,17 +999,17 @@ JITAssembler64 >> loadRwithMindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithNil [
+JITAssemblerAMD64 >> loadRwithNil [
 	self assemble: 'mov' with: self regR with: self regNil
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadRwithRatA [
+JITAssemblerAMD64 >> loadRwithRatA [
 	self load: self regR from: self regR atIndexAt: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithRatOffsetA [
+JITAssemblerAMD64 >> loadRwithRatOffsetA [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1019,7 +1019,7 @@ JITAssembler64 >> loadRwithRatOffsetA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithRbyte: index [
+JITAssemblerAMD64 >> loadRwithRbyte: index [
 	pointer
 		reset;
 		length: 8;
@@ -1032,12 +1032,12 @@ JITAssembler64 >> loadRwithRbyte: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithRindex: index [
+JITAssemblerAMD64 >> loadRwithRindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regR index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithRwordAt: index [
+JITAssemblerAMD64 >> loadRwithRwordAt: index [
 	pointer
 		reset;
 		length: 16;
@@ -1050,22 +1050,22 @@ JITAssembler64 >> loadRwithRwordAt: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithS [
+JITAssemblerAMD64 >> loadRwithS [
 	self assemble: 'mov' with: self regR with: self regS
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithSP [
+JITAssemblerAMD64 >> loadRwithSP [
 	self assemble: 'mov' with: self regR with: self regSP
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithSPindex: index [
+JITAssemblerAMD64 >> loadRwithSPindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regSP index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithSbyte: index [
+JITAssemblerAMD64 >> loadRwithSbyte: index [
 	pointer
 		reset;
 		length: 8;
@@ -1078,17 +1078,17 @@ JITAssembler64 >> loadRwithSbyte: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithSindex: index [
+JITAssemblerAMD64 >> loadRwithSindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regS index: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadRwithSmallInteger: anInteger [
+JITAssemblerAMD64 >> loadRwithSmallInteger: anInteger [
 	self loadRwithImmediate: (anInteger bitShift: 1) + 1
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithSwordAt: index [
+JITAssemblerAMD64 >> loadRwithSwordAt: index [
 	pointer
 		reset;
 		length: 16;
@@ -1101,12 +1101,12 @@ JITAssembler64 >> loadRwithSwordAt: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithT [
+JITAssemblerAMD64 >> loadRwithT [
 	self assemble: 'mov' with: self regR with: self regT
 ]
 
 { #category : #storing }
-JITAssembler64 >> loadRwithTIBatIndexR [
+JITAssemblerAMD64 >> loadRwithTIBatIndexR [
 	| seg |
 	seg := wordSize = 8 ifTrue: [gs] ifFalse: [fs].
 	pointer
@@ -1119,7 +1119,7 @@ JITAssembler64 >> loadRwithTIBatIndexR [
 ]
 
 { #category : #storing }
-JITAssembler64 >> loadRwithThreadVariableAtIndexR [
+JITAssemblerAMD64 >> loadRwithThreadVariableAtIndexR [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1132,50 +1132,50 @@ JITAssembler64 >> loadRwithThreadVariableAtIndexR [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithTindex: index [
+JITAssemblerAMD64 >> loadRwithTindex: index [
 	self assemble: 'mov' withReg: self regR withReg: self regT index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithTos [
+JITAssemblerAMD64 >> loadRwithTos [
 	pointer reset; length: self addressLength; base: self regSP.
 	self assemble: 'mov' with: self regR with: pointer
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithTrue [
+JITAssemblerAMD64 >> loadRwithTrue [
 	self assemble: 'mov' with: self regR with: self regTrue
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadRwithX0 [
+JITAssemblerAMD64 >> loadRwithX0 [
 	| mov |
 	mov := wordSize = 8 ifTrue: ['movq'] ifFalse: ['movd'].
 	self assemble: mov with: self regR with: xmm0
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSPwithFP [
+JITAssemblerAMD64 >> loadSPwithFP [
 	self assemble: 'mov' with: self regSP with: self regFP
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSPwithT [
+JITAssemblerAMD64 >> loadSPwithT [
 	self assemble: 'mov' with: self regSP with: self regT
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSWithRIndex: index [
+JITAssemblerAMD64 >> loadSWithRIndex: index [
 	self load: self regS from: self regR atIndex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithA [
+JITAssemblerAMD64 >> loadSwithA [
 	self assemble: 'mov' with: self regS with: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadSwithAddressOfSatA [
+JITAssemblerAMD64 >> loadSwithAddressOfSatA [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1187,90 +1187,90 @@ JITAssembler64 >> loadSwithAddressOfSatA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithFPindex: index [
+JITAssemblerAMD64 >> loadSwithFPindex: index [
 	self assemble: 'mov' withReg: self regS withReg: self regFP index: index
 ]
 
 { #category : #private }
-JITAssembler64 >> loadSwithGindex: index [
+JITAssemblerAMD64 >> loadSwithGindex: index [
 	self assemble: 'mov' withReg: self regS withReg: self regG index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithGlobal: aSymbol [
+JITAssemblerAMD64 >> loadSwithGlobal: aSymbol [
 	| index |
 	index := NativizationEnvironment indexOfGlobal: aSymbol.
 	self loadSwithGindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithImmediate: imm [
+JITAssemblerAMD64 >> loadSwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regS withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithNil [
+JITAssemblerAMD64 >> loadSwithNil [
 	self assemble: 'mov' with: self regS with: self regNil
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithRindex: index [
+JITAssemblerAMD64 >> loadSwithRindex: index [
 	self assemble: 'mov' withReg: self regS withReg: self regR index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadSwithT [
+JITAssemblerAMD64 >> loadSwithT [
 	self assemble: 'mov' with: self regS with: self regT
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTrueWithLiteral: anObject [
+JITAssemblerAMD64 >> loadTrueWithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadTrueWithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTrueWithMindex: index [
+JITAssemblerAMD64 >> loadTrueWithMindex: index [
 	self assemble: 'mov' withReg: self regTrue withReg: self regM index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithA [
+JITAssemblerAMD64 >> loadTwithA [
 	self assemble: 'mov' with: self regT with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithAindex: index [
+JITAssemblerAMD64 >> loadTwithAindex: index [
 	self assemble: 'mov' withReg: self regT withReg: self regA index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithEindex: index [
+JITAssemblerAMD64 >> loadTwithEindex: index [
 	self assemble: 'mov' withReg: self regT withReg: self regE index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithFPindex: index [
+JITAssemblerAMD64 >> loadTwithFPindex: index [
 	self assemble: 'mov' withReg: self regT withReg: self regFP index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithImmediate: imm [
+JITAssemblerAMD64 >> loadTwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regT withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithLiteral: anObject [
+JITAssemblerAMD64 >> loadTwithLiteral: anObject [
 	| index |
 	index := self addLiteral: anObject.
 	self loadTwithMindex: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithMindex: index [
+JITAssemblerAMD64 >> loadTwithMindex: index [
 	self
 		assemble: 'mov'
 		withReg: self regT
@@ -1279,28 +1279,28 @@ JITAssembler64 >> loadTwithMindex: index [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithR [
+JITAssemblerAMD64 >> loadTwithR [
 	self assemble: 'mov' with: self regT with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadTwithTindex: index [
+JITAssemblerAMD64 >> loadTwithTindex: index [
 	self assemble: 'mov' withReg: self regT withReg: self regT index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadVwithImmediate: imm [
+JITAssemblerAMD64 >> loadVwithImmediate: imm [
 	#imm32.
 	self assemble: 'mov' with: self regV withImm: imm
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadWithFalse: register [
+JITAssemblerAMD64 >> loadWithFalse: register [
 	self assemble: 'mov' with: register with: self regFalse
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadWithNil: register [
+JITAssemblerAMD64 >> loadWithNil: register [
 	self
 		assemble: 'mov'
 		with: register
@@ -1308,55 +1308,55 @@ JITAssembler64 >> loadWithNil: register [
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadWithTrue: register [
+JITAssemblerAMD64 >> loadWithTrue: register [
 	self assemble: 'mov' with: register with: self regTrue
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadX0withRasDouble [
+JITAssemblerAMD64 >> loadX0withRasDouble [
 	self assemble: 'cvtsi2sd' with: xmm0 with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> loadX1roundingX0 [
+JITAssemblerAMD64 >> loadX1roundingX0 [
 	self assemble: 'roundsd' with: xmm1 with: xmm0 with: 3
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendByteRwithRatA [
+JITAssemblerAMD64 >> loadZeroExtendByteRwithRatA [
 	self loadZeroExtendByte: self regR from: self regR atIndexAt: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendByteRwithRindex: index [
+JITAssemblerAMD64 >> loadZeroExtendByteRwithRindex: index [
 	#dontOptimize.
 	self loadZeroExtendByte: self regR from: self regR atIndex: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendByteRwithSPatA [
+JITAssemblerAMD64 >> loadZeroExtendByteRwithSPatA [
 	self loadZeroExtendByte: self regR from: self regSP atIndexAt: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendByteTwithAindex: index [
+JITAssemblerAMD64 >> loadZeroExtendByteTwithAindex: index [
 	#dontOptimize.
 	self loadZeroExtendByte: self regT from: self regA atIndex: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendLongRwithRatA [
+JITAssemblerAMD64 >> loadZeroExtendLongRwithRatA [
 	self load: self regR e from: self regR atIndexAt: self regA
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendLongRwithRindex: index [
+JITAssemblerAMD64 >> loadZeroExtendLongRwithRindex: index [
 	#dontOptimize.
 	self load: self regR e from: self regR atIndex: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> loadZeroExtendShortRwithRoffset: offset [
+JITAssemblerAMD64 >> loadZeroExtendShortRwithRoffset: offset [
 	pointer
 		reset;
 		length: 16;
@@ -1366,12 +1366,12 @@ JITAssembler64 >> loadZeroExtendShortRwithRoffset: offset [
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> lock [
+JITAssemblerAMD64 >> lock [
 	self assembleByte: 16rF0
 ]
 
 { #category : #jumps }
-JITAssembler64 >> loop: aBlock times: anInteger [
+JITAssemblerAMD64 >> loop: aBlock times: anInteger [
 	| loop |
 	loop := self newLabel.
 	self loadTwithImmediate: anInteger; @ loop.
@@ -1380,14 +1380,14 @@ JITAssembler64 >> loop: aBlock times: anInteger [
 ]
 
 { #category : #jumps }
-JITAssembler64 >> loopTo: label [
+JITAssemblerAMD64 >> loopTo: label [
 	self
 		assemble: 'dec' with: self regT;
 		jumpIfNotZeroTo: label
 ]
 
 { #category : #jumps }
-JITAssembler64 >> loopTtimes: aBlock [
+JITAssemblerAMD64 >> loopTtimes: aBlock [
 	| loop end |
 	loop := self newLabel.
 	end := self newLabel.
@@ -1403,7 +1403,7 @@ JITAssembler64 >> loopTtimes: aBlock [
 ]
 
 { #category : #'opcodes - integer related' }
-JITAssembler64 >> moveTslots [
+JITAssemblerAMD64 >> moveTslots [
 	| rep mnemonic |
 	rep := 16rF3.
 	mnemonic := wordSize = 8 ifTrue: ['movsq'] ifFalse: ['movsd'].
@@ -1411,115 +1411,115 @@ JITAssembler64 >> moveTslots [
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> multiplyDoubleX0byX1 [
+JITAssemblerAMD64 >> multiplyDoubleX0byX1 [
 	self assemble: 'mulsd' with: xmm0 with: xmm1
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> multiplyRbyA [
+JITAssemblerAMD64 >> multiplyRbyA [
 	self ASSERT: (self regR r == rax and: [self regA r == rdx]).
 	self assemble: 'imul' with: self regA
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> multiplyRbyConstant: imm [
+JITAssemblerAMD64 >> multiplyRbyConstant: imm [
 	self assemble: 'imul' with: self regR with: self regR with: imm
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> nativeCode [
+JITAssemblerAMD64 >> nativeCode [
 	^(NativeCode withAll: literals) code: memory bytes
 ]
 
 { #category : #logic }
-JITAssembler64 >> orRwithA [
+JITAssemblerAMD64 >> orRwithA [
 	self assemble: 'or' with: self regR with: self regA
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popA [
+JITAssemblerAMD64 >> popA [
 	self assemble: 'pop' with: self regA
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popB [
+JITAssemblerAMD64 >> popB [
 	self assemble: 'pop' with: self regB
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popE [
+JITAssemblerAMD64 >> popE [
 	self assemble: 'pop' with: self regE
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popFP [
+JITAssemblerAMD64 >> popFP [
 	self assemble: 'pop' with: self regFP
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popFalse [
+JITAssemblerAMD64 >> popFalse [
 	self assemble: 'pop' with: self regFalse
 ]
 
 { #category : #private }
-JITAssembler64 >> popG [
+JITAssemblerAMD64 >> popG [
 	self assemble: 'pop' with: self regG
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popM [
+JITAssemblerAMD64 >> popM [
 	self assemble: 'pop' with: self regM
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popNil [
+JITAssemblerAMD64 >> popNil [
 	self assemble: 'pop' with: self regNil
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popR [
+JITAssemblerAMD64 >> popR [
 	self assemble: 'pop' with: self regR
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popS [
+JITAssemblerAMD64 >> popS [
 	self assemble: 'pop' with: self regS
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popSP [
+JITAssemblerAMD64 >> popSP [
 	self assemble: 'pop' with: self regSP
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popSPindirect [
+JITAssemblerAMD64 >> popSPindirect [
 	pointer reset; length: self addressLength; base: self regSP.
 	self assemble: 'pop' with: pointer
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popT [
+JITAssemblerAMD64 >> popT [
 	self assemble: 'pop' with: self regT
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> popTrue [
+JITAssemblerAMD64 >> popTrue [
 	self assemble: 'pop' with: self regTrue
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushA [
+JITAssemblerAMD64 >> pushA [
 	self assemble: 'push' with: self regA
 ]
 
 { #category : #loading }
-JITAssembler64 >> pushAOnFPUStack [
+JITAssemblerAMD64 >> pushAOnFPUStack [
 	pointer reset; length: 64; base: self regA.
 	self assemble: 'fld' with: pointer
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushAatToffset: offset [
+JITAssemblerAMD64 >> pushAatToffset: offset [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1531,76 +1531,76 @@ JITAssembler64 >> pushAatToffset: offset [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushB [
+JITAssemblerAMD64 >> pushB [
 	self assemble: 'push' with: self regB
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushE [
+JITAssemblerAMD64 >> pushE [
 	self assemble: 'push' with: self regE
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushEindex: index [
+JITAssemblerAMD64 >> pushEindex: index [
 	self assemble: 'push' withReg: self regE index: index
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushFP [
+JITAssemblerAMD64 >> pushFP [
 	self assemble: 'push' with: self regFP
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushFPindex: index [
+JITAssemblerAMD64 >> pushFPindex: index [
 	self assemble: 'push' withReg: self regFP index: index
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushFalse [
+JITAssemblerAMD64 >> pushFalse [
 	self assemble: 'push' with: self regFalse
 ]
 
 { #category : #private }
-JITAssembler64 >> pushG [
+JITAssemblerAMD64 >> pushG [
 	self assemble: 'push' with: self regG
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushImmediate: imm [
+JITAssemblerAMD64 >> pushImmediate: imm [
 	#imm8.
 	#imm32.
 	self assemble: 'push' withImm: imm
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushIndirectR [
+JITAssemblerAMD64 >> pushIndirectR [
 	pointer reset; length: self addressLength; base: self regR.
 	self assemble: 'push' with: pointer
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushM [
+JITAssemblerAMD64 >> pushM [
 	self assemble: 'push' with: self regM
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushNil [
+JITAssemblerAMD64 >> pushNil [
 	self assemble: 'push' with: self regNil
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushR [
+JITAssemblerAMD64 >> pushR [
 	self assemble: 'push' with: self regR
 ]
 
 { #category : #loading }
-JITAssembler64 >> pushROnFPUStack [
+JITAssemblerAMD64 >> pushROnFPUStack [
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'fld' with: pointer
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushRbyte: index [
+JITAssemblerAMD64 >> pushRbyte: index [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1613,7 +1613,7 @@ JITAssembler64 >> pushRbyte: index [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushRwordAt: index [
+JITAssemblerAMD64 >> pushRwordAt: index [
 	pointer
 		halt;
 		reset;
@@ -1627,17 +1627,17 @@ JITAssembler64 >> pushRwordAt: index [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushS [
+JITAssemblerAMD64 >> pushS [
 	self assemble: 'push' with: self regS
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushSP [
+JITAssemblerAMD64 >> pushSP [
 	self assemble: 'push' with: self regSP
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushSbyte: index [
+JITAssemblerAMD64 >> pushSbyte: index [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1650,17 +1650,17 @@ JITAssembler64 >> pushSbyte: index [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushSindex: index [
+JITAssemblerAMD64 >> pushSindex: index [
 	self assemble: 'push' withReg: self regS index: index
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushSmallInteger: integer [
+JITAssemblerAMD64 >> pushSmallInteger: integer [
 	self pushImmediate: (integer bitShift: 1) + 1
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushSwordAt: index [
+JITAssemblerAMD64 >> pushSwordAt: index [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1673,245 +1673,245 @@ JITAssembler64 >> pushSwordAt: index [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushT [
+JITAssemblerAMD64 >> pushT [
 	self assemble: 'push' with: self regT
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushTindex: index [
+JITAssemblerAMD64 >> pushTindex: index [
 	self assemble: 'push' withReg: self regT index: index
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushTrue [
+JITAssemblerAMD64 >> pushTrue [
 	self assemble: 'push' with: self regTrue
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> pushVindex: index [
+JITAssemblerAMD64 >> pushVindex: index [
 	self assemble: 'push' withReg: self regV index: index
 ]
 
 { #category : #services }
-JITAssembler64 >> readFPUStatusOnA [
+JITAssemblerAMD64 >> readFPUStatusOnA [
 	pointer reset; length: 16; base: self regA.
 	self assemble: 'fstsw' with: pointer
 ]
 
 { #category : #private }
-JITAssembler64 >> regA [
+JITAssemblerAMD64 >> regA [
 	^wordSize = 8 ifTrue: [rdx] ifFalse: [edx]
 ]
 
 { #category : #private }
-JITAssembler64 >> regA8 [
+JITAssemblerAMD64 >> regA8 [
 	^dl
 ]
 
 { #category : #private }
-JITAssembler64 >> regB [
+JITAssemblerAMD64 >> regB [
 	^wordSize = 8 ifTrue: [rbx] ifFalse: [ebx]
 ]
 
 { #category : #private }
-JITAssembler64 >> regC [
+JITAssemblerAMD64 >> regC [
 	^wordSize = 8 ifTrue: [rbx] ifFalse: [ebx]
 ]
 
 { #category : #private }
-JITAssembler64 >> regE [
+JITAssemblerAMD64 >> regE [
 	^wordSize = 8 ifTrue: [rdi] ifFalse: [edi]
 ]
 
 { #category : #private }
-JITAssembler64 >> regFP [
+JITAssemblerAMD64 >> regFP [
 	^wordSize = 8 ifTrue: [rbp] ifFalse: [ebp]
 ]
 
 { #category : #private }
-JITAssembler64 >> regFalse [
+JITAssemblerAMD64 >> regFalse [
 	^ r14
 ]
 
 { #category : #private }
-JITAssembler64 >> regG [
+JITAssemblerAMD64 >> regG [
 	^r15
 ]
 
 { #category : #private }
-JITAssembler64 >> regIP [
+JITAssemblerAMD64 >> regIP [
 	^ rip
 ]
 
 { #category : #private }
-JITAssembler64 >> regM [
+JITAssemblerAMD64 >> regM [
 	^rbx
 ]
 
 { #category : #private }
-JITAssembler64 >> regNil [
+JITAssemblerAMD64 >> regNil [
 	^ r12
 ]
 
 { #category : #private }
-JITAssembler64 >> regR [
+JITAssemblerAMD64 >> regR [
 	^wordSize = 8 ifTrue: [rax] ifFalse: [eax]
 ]
 
 { #category : #private }
-JITAssembler64 >> regR8 [
+JITAssemblerAMD64 >> regR8 [
 	^al
 ]
 
 { #category : #private }
-JITAssembler64 >> regS [
+JITAssemblerAMD64 >> regS [
 	^wordSize = 8 ifTrue: [rsi] ifFalse: [esi]
 ]
 
 { #category : #private }
-JITAssembler64 >> regSP [
+JITAssemblerAMD64 >> regSP [
 	^wordSize = 8 ifTrue: [rsp] ifFalse: [esp]
 ]
 
 { #category : #private }
-JITAssembler64 >> regT [
+JITAssemblerAMD64 >> regT [
 	^wordSize = 8 ifTrue: [rcx] ifFalse: [ecx]
 ]
 
 { #category : #private }
-JITAssembler64 >> regT8 [
+JITAssemblerAMD64 >> regT8 [
 	^ cl
 ]
 
 { #category : #private }
-JITAssembler64 >> regTrue [
+JITAssemblerAMD64 >> regTrue [
 	^ r13
 ]
 
 { #category : #private }
-JITAssembler64 >> reserveStackSlots: amount [
+JITAssemblerAMD64 >> reserveStackSlots: amount [
 	self subtract: amount * self addressSize from: self regSP
 ]
 
 { #category : #comparing }
-JITAssembler64 >> reset [
+JITAssemblerAMD64 >> reset [
 	super reset.
 	literals := OrderedCollection new
 ]
 
 { #category : #epilogue }
-JITAssembler64 >> restoreCallerEnvironment [
+JITAssemblerAMD64 >> restoreCallerEnvironment [
 	self loadEwithFPindex: -2
 ]
 
 { #category : #epilogue }
-JITAssembler64 >> restoreCallerFrame [
+JITAssemblerAMD64 >> restoreCallerFrame [
 	self
 		move: self regFP to: self regSP;
 		pop: self regFP
 ]
 
 { #category : #epilogue }
-JITAssembler64 >> restoreCallerM [
+JITAssemblerAMD64 >> restoreCallerM [
 	self loadMwithFPindex: -1
 ]
 
 { #category : #epilogue }
-JITAssembler64 >> restoreCallerSelf [
+JITAssemblerAMD64 >> restoreCallerSelf [
 	self loadSwithFPindex: 0
 ]
 
 { #category : #integers }
-JITAssembler64 >> restoreRSmallInteger [
+JITAssemblerAMD64 >> restoreRSmallInteger [
 	self assemble: 'rcl' with: self regR with: 1
 ]
 
 { #category : #integers }
-JITAssembler64 >> restoreRsmallInteger [
+JITAssemblerAMD64 >> restoreRsmallInteger [
 	self assemble: 'rcl' with: self regR with: 1
 ]
 
 { #category : #services }
-JITAssembler64 >> returnFromCallback: argCount [
+JITAssemblerAMD64 >> returnFromCallback: argCount [
 	wordSize = 4 ifTrue: [self return: argCount] ifFalse: [self return]
 ]
 
 { #category : #loading }
-JITAssembler64 >> saveCallerFrame [
+JITAssemblerAMD64 >> saveCallerFrame [
 	self pushFP; loadFPwithSP
 ]
 
 { #category : #loading }
-JITAssembler64 >> scaleFloatOnRWithA [
+JITAssemblerAMD64 >> scaleFloatOnRWithA [
 	self pushAOnFPUStack; pushROnFPUStack; assemble: 'fscale'.
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'fstp' with: pointer; dropTopOfFPU
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftLeftRwithT [
+JITAssemblerAMD64 >> shiftLeftRwithT [
 	self ASSERT: self regT r == rcx.
 	self assemble: 'sal' with: self regR with: self regT b
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftLogicalRright: count [
+JITAssemblerAMD64 >> shiftLogicalRright: count [
 	self ASSERT: count < 32.
 	self assemble: 'shr' with: self regR with: count
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftRightRwithT [
+JITAssemblerAMD64 >> shiftRightRwithT [
 	self ASSERT: self regT r == rcx.
 	self assemble: 'sar' with: self regR with: self regT b
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftRleft: count [
+JITAssemblerAMD64 >> shiftRleft: count [
 	self ASSERT: count < 32.
 	self assemble: 'sal' with: self regR with: count
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftRright: count [
+JITAssemblerAMD64 >> shiftRright: count [
 	self ASSERT: count < (wordSize * 8).
 	self assemble: 'sar' with: self regR with: count
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftTleft: count [
+JITAssemblerAMD64 >> shiftTleft: count [
 	self ASSERT: count < 32.
 	self assemble: 'sal' with: self regT with: count
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> shiftTright: count [
+JITAssemblerAMD64 >> shiftTright: count [
 	self ASSERT: count < 32.
 	self assemble: 'sar' with: self regT with: count
 ]
 
 { #category : #comparing }
-JITAssembler64 >> smallInteger: anInteger [
+JITAssemblerAMD64 >> smallInteger: anInteger [
 	^(anInteger bitShift: 1) + 1
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> sqrtDoubleX0 [
+JITAssemblerAMD64 >> sqrtDoubleX0 [
 	self assemble: 'sqrtsd' with: xmm0 with: xmm0
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeAinRindex: index [
+JITAssemblerAMD64 >> storeAinRindex: index [
 	self store: self regA in: self regR index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeAinSPatT [
+JITAssemblerAMD64 >> storeAinSPatT [
 	self store: self regA in: self regSP indexAt: self regT
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeAinThreadVariableAtIndexR [
+JITAssemblerAMD64 >> storeAinThreadVariableAtIndexR [
 	pointer
 		reset;
 		length: self addressLength;
@@ -1924,12 +1924,12 @@ JITAssembler64 >> storeAinThreadVariableAtIndexR [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeAinTindex: index [
+JITAssemblerAMD64 >> storeAinTindex: index [
 	self store: self regA in: self regT index: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> storeArgumentsInStack [
+JITAssemblerAMD64 >> storeArgumentsInStack [
 	self
 		store: rcx in: rbp index: 3;
 		store: rdx in: rbp index: 4;
@@ -1938,7 +1938,7 @@ JITAssembler64 >> storeArgumentsInStack [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeByteAinRindex: index [
+JITAssemblerAMD64 >> storeByteAinRindex: index [
 	#dontOptimize.
 	pointer
 		reset;
@@ -1949,7 +1949,7 @@ JITAssembler64 >> storeByteAinRindex: index [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeByteTinRatA [
+JITAssemblerAMD64 >> storeByteTinRatA [
 	pointer
 		reset;
 		length: 8;
@@ -1960,7 +1960,7 @@ JITAssembler64 >> storeByteTinRatA [
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> storeDoubleResultInRindirect [
+JITAssemblerAMD64 >> storeDoubleResultInRindirect [
 	pointer reset; length: 64; base: self regR.
 	wordSize = 8
 		ifTrue: [self assemble: 'movq' with: pointer with: xmm0]
@@ -1968,45 +1968,45 @@ JITAssembler64 >> storeDoubleResultInRindirect [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeEinAindex: index [
+JITAssemblerAMD64 >> storeEinAindex: index [
 	self store: self regE in: self regA index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeEinRindex: index [
+JITAssemblerAMD64 >> storeEinRindex: index [
 	self store: self regE in: self regR index: index
 ]
 
 { #category : #loading }
-JITAssembler64 >> storeLargeX0inA [
+JITAssemblerAMD64 >> storeLargeX0inA [
 	pointer reset; length: 64; base: self regA.
 	self assemble: 'movq' with: pointer with: xmm0
 ]
 
 { #category : #loading }
-JITAssembler64 >> storeLargeX0inR [
+JITAssemblerAMD64 >> storeLargeX0inR [
 	pointer reset; length: 64; base: self regR.
 	self assemble: 'movq' with: pointer with: xmm0
 ]
 
 { #category : #loading }
-JITAssembler64 >> storeLargeX0inT [
+JITAssemblerAMD64 >> storeLargeX0inT [
 	pointer reset; length: 64; base: self regT.
 	self assemble: 'movq' with: pointer with: xmm0
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeLongTInRAtA [
+JITAssemblerAMD64 >> storeLongTInRAtA [
 	self store: self regT e in: self regR indexAt: self regA
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeLongTinRatA [
+JITAssemblerAMD64 >> storeLongTinRatA [
 	self store: self regT e in: self regR indexAt: self regA
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeLongTinRatOffsetA [
+JITAssemblerAMD64 >> storeLongTinRatOffsetA [
 	pointer
 		reset;
 		length: 32;
@@ -2016,28 +2016,28 @@ JITAssembler64 >> storeLongTinRatOffsetA [
 ]
 
 { #category : #loading }
-JITAssembler64 >> storeMXCSRintoA [
+JITAssemblerAMD64 >> storeMXCSRintoA [
 	pointer reset; length: 32; base: self regA.
 	self assemble: 'stmxcsr' with: pointer
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinAindex: index [
+JITAssemblerAMD64 >> storeRinAindex: index [
 	self store: self regR in: self regA index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinEindex: index [
+JITAssemblerAMD64 >> storeRinEindex: index [
 	self store: self regR in: self regE index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinFPindex: index [
+JITAssemblerAMD64 >> storeRinFPindex: index [
 	self store: self regR in: self regFP index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinSbyte: index [
+JITAssemblerAMD64 >> storeRinSbyte: index [
 	pointer
 		reset;
 		length: 8;
@@ -2047,12 +2047,12 @@ JITAssembler64 >> storeRinSbyte: index [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinSindex: index [
+JITAssemblerAMD64 >> storeRinSindex: index [
 	self store: self regR in: self regS index: index
 ]
 
 { #category : #'push/pop' }
-JITAssembler64 >> storeRinSwordAt: index [
+JITAssemblerAMD64 >> storeRinSwordAt: index [
 	pointer
 		reset;
 		length: 16;
@@ -2065,12 +2065,12 @@ JITAssembler64 >> storeRinSwordAt: index [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeRinTindex: index [
+JITAssemblerAMD64 >> storeRinTindex: index [
 	self store: self regR in: self regT index: index
 ]
 
 { #category : #integers }
-JITAssembler64 >> storeShortAinRoffset: offset [
+JITAssemblerAMD64 >> storeShortAinRoffset: offset [
 	pointer
 		reset;
 		length: 16;
@@ -2080,7 +2080,7 @@ JITAssembler64 >> storeShortAinRoffset: offset [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeShortTinRatOffsetA [
+JITAssemblerAMD64 >> storeShortTinRatOffsetA [
 	pointer
 		reset;
 		length: 16;
@@ -2090,17 +2090,17 @@ JITAssembler64 >> storeShortTinRatOffsetA [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeSinAindex: index [
+JITAssemblerAMD64 >> storeSinAindex: index [
 	self store: self regS in: self regA index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeSinRindex: index [
+JITAssemblerAMD64 >> storeSinRindex: index [
 	self store: self regS in: self regR index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTIBwithAatIndexR [
+JITAssemblerAMD64 >> storeTIBwithAatIndexR [
 	| seg |
 	seg := wordSize = 8 ifTrue: [gs] ifFalse: [fs].
 	pointer
@@ -2113,22 +2113,22 @@ JITAssembler64 >> storeTIBwithAatIndexR [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTInRAtA [
+JITAssemblerAMD64 >> storeTInRAtA [
 	self store: self regT in: self regR indexAt: self regA
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTinAindex: index [
+JITAssemblerAMD64 >> storeTinAindex: index [
 	self store: self regT in: self regA index: index
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTinRatA [
+JITAssemblerAMD64 >> storeTinRatA [
 	self store: self regT in: self regR indexAt: self regA
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTinRatOffsetA [
+JITAssemblerAMD64 >> storeTinRatOffsetA [
 	pointer
 		reset;
 		length: self addressLength;
@@ -2138,37 +2138,37 @@ JITAssembler64 >> storeTinRatOffsetA [
 ]
 
 { #category : #storing }
-JITAssembler64 >> storeTinRindex: index [
+JITAssemblerAMD64 >> storeTinRindex: index [
 	self store: self regT in: self regR index: index
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subAfromR [
+JITAssemblerAMD64 >> subAfromR [
 	self assemble: 'sub' with: self regR with: self regA
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subAfromT [
+JITAssemblerAMD64 >> subAfromT [
 	self assemble: 'sub' with: self regT with: self regA
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subDoubleX1fromX0 [
+JITAssemblerAMD64 >> subDoubleX1fromX0 [
 	self assemble: 'subsd' with: xmm0 with: xmm1
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subFromRconstant: imm [
+JITAssemblerAMD64 >> subFromRconstant: imm [
 	self assemble: 'sub' with: self regR withImm: imm
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subTfromR [
+JITAssemblerAMD64 >> subTfromR [
 	self assemble: 'sub' with: self regR with: self regT
 ]
 
 { #category : #arithmetic }
-JITAssembler64 >> subTslotsToSP [
+JITAssemblerAMD64 >> subTslotsToSP [
 	self assemble: 'neg' with: self regT.
 	pointer
 		reset;
@@ -2182,42 +2182,42 @@ JITAssembler64 >> subTslotsToSP [
 ]
 
 { #category : #integers }
-JITAssembler64 >> testAintegerBit [
+JITAssemblerAMD64 >> testAintegerBit [
 	self assemble: 'test' with: self regA8 with: 1
 ]
 
 { #category : #integers }
-JITAssembler64 >> testIntegerBitOf: aRegister [
+JITAssemblerAMD64 >> testIntegerBitOf: aRegister [
 	self assemble: 'test' with: aRegister byte with: 1
 ]
 
 { #category : #integers }
-JITAssembler64 >> testRintegerBit [
+JITAssemblerAMD64 >> testRintegerBit [
 	self assemble: 'test' with: self regR8 with: 1
 ]
 
 { #category : #loading }
-JITAssembler64 >> testRwithR [
+JITAssemblerAMD64 >> testRwithR [
 	self assemble: 'test' with: self regR with: self regR
 ]
 
 { #category : #integers }
-JITAssembler64 >> testTIntegerBit [
+JITAssemblerAMD64 >> testTIntegerBit [
 	self assemble: 'test' with: self regT byte with: 1
 ]
 
 { #category : #integers }
-JITAssembler64 >> testTintegerBit [
+JITAssemblerAMD64 >> testTintegerBit [
 	self assemble: 'test' with: self regT byte with: 1
 ]
 
 { #category : #services }
-JITAssembler64 >> wordSize [
+JITAssemblerAMD64 >> wordSize [
 	^wordSize
 ]
 
 { #category : #'opcodes - integer related' }
-JITAssembler64 >> writeTslots [
+JITAssemblerAMD64 >> writeTslots [
 	| rep mnemonic |
 	rep := 16rF3.
 	mnemonic := wordSize = 8 ifTrue: ['stosq'] ifFalse: ['stosd'].
@@ -2225,16 +2225,16 @@ JITAssembler64 >> writeTslots [
 ]
 
 { #category : #logic }
-JITAssembler64 >> xorAwithR [
+JITAssemblerAMD64 >> xorAwithR [
 	self assemble: 'xor' with: self regA with: self regR
 ]
 
 { #category : #logic }
-JITAssembler64 >> xorFPwithFP [
+JITAssemblerAMD64 >> xorFPwithFP [
 	self assemble: 'xor' with: self regFP with: self regFP
 ]
 
 { #category : #logic }
-JITAssembler64 >> xorRwithA [
+JITAssemblerAMD64 >> xorRwithA [
 	self assemble: 'xor' with: self regR with: self regA
 ]

--- a/bootstrap/src/Powerlang-Core/NativeCodeReference.class.st
+++ b/bootstrap/src/Powerlang-Core/NativeCodeReference.class.st
@@ -7,7 +7,7 @@ Class {
 		'target',
 		'absolute'
 	],
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#category : #'Powerlang-Core-Assembler'
 }
 
 { #category : #'as yet unclassified' }

--- a/bootstrap/src/Powerlang-Core/NativizationEnvironment.class.st
+++ b/bootstrap/src/Powerlang-Core/NativizationEnvironment.class.st
@@ -195,7 +195,7 @@ NativizationEnvironment >> methodNativizer [
 { #category : #services }
 NativizationEnvironment >> monomorphicCache [
 	| asm lookup next |
-	asm := TemplateAssembler64 new.
+	asm := TemplateAssemblerAMD64 new.
 	asm wordSize: abi wordSize.
 	lookup := asm newLabel.
 	asm
@@ -275,7 +275,7 @@ NativizationEnvironment >> optimizingNativizer [
 { #category : #services }
 NativizationEnvironment >> polymorphicCache [
 	| asm smi case2 case3 case4 case5 case6 case7 lookup |
-	asm := TemplateAssembler64 new.
+	asm := TemplateAssemblerAMD64 new.
 	asm wordSize: abi wordSize.
 	smi := asm newLabel.
 	case2 := asm newLabel.

--- a/bootstrap/src/Powerlang-Core/OptimizingCodeEmitter.class.st
+++ b/bootstrap/src/Powerlang-Core/OptimizingCodeEmitter.class.st
@@ -767,7 +767,7 @@ OptimizingCodeEmitter >> initializeAssemblers [
 
 { #category : #initialization }
 OptimizingCodeEmitter >> initializeLowLevelAssembler [
-	assembler := TemplateAssembler64 new
+	assembler := TemplateAssemblerAMD64 new
 ]
 
 { #category : #unclassified }

--- a/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
+++ b/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
@@ -83,6 +83,18 @@ RelocatableBuffer >> nextBytesPut: aByteArray [
 ]
 
 { #category : #writing }
+RelocatableBuffer >> nextLargePut: large [
+	stream nextLargePut: large
+
+]
+
+{ #category : #writing }
+RelocatableBuffer >> nextLongPut: long [
+	stream nextLongPut: long
+
+]
+
+{ #category : #writing }
 RelocatableBuffer >> nextPut: byte [
 	stream nextPut: byte
 ]
@@ -93,8 +105,9 @@ RelocatableBuffer >> nextPutAll: aByteArray [
 ]
 
 { #category : #writing }
-RelocatableBuffer >> nextULargePut: long [
-	stream nextULargePut: long
+RelocatableBuffer >> nextULargePut: large [
+	stream nextULargePut: large
+
 ]
 
 { #category : #writing }

--- a/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
+++ b/bootstrap/src/Powerlang-Core/RelocatableBuffer.class.st
@@ -10,7 +10,7 @@ Class {
 		'address',
 		'fixups'
 	],
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#category : #'Powerlang-Core-Assembler'
 }
 
 { #category : #'instance creation' }

--- a/bootstrap/src/Powerlang-Core/RelocationFixup.class.st
+++ b/bootstrap/src/Powerlang-Core/RelocationFixup.class.st
@@ -11,7 +11,7 @@ Class {
 		'relative',
 		'size'
 	],
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#category : #'Powerlang-Core-Assembler'
 }
 
 { #category : #'instance creation' }

--- a/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
+++ b/bootstrap/src/Powerlang-Core/SExpressionNativizer.class.st
@@ -414,7 +414,7 @@ SExpressionNativizer >> falseLiteral [
 { #category : #initialization }
 SExpressionNativizer >> initialize [
 	super initialize.
-	assembler := TemplateAssembler64 new
+	assembler := TemplateAssemblerAMD64 new
 ]
 
 { #category : #services }

--- a/bootstrap/src/Powerlang-Core/TemplateAssemblerAMD64.class.st
+++ b/bootstrap/src/Powerlang-Core/TemplateAssemblerAMD64.class.st
@@ -3,31 +3,31 @@ Copyright (c) 2020 Aucerna.
     See (MIT) license in root directory.
 "
 Class {
-	#name : #TemplateAssembler64,
-	#superclass : #JITAssembler64,
-	#category : #'Powerlang-Core-Assembler-JIT'
+	#name : #TemplateAssemblerAMD64,
+	#superclass : #JITAssemblerAMD64,
+	#category : #'Powerlang-Core-Assembler-Intel'
 }
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addAtoR [
+TemplateAssemblerAMD64 >> addAtoR [
 	self assembleBytes: #[16r48 16r1 16rD0].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addDoubleX1toX0 [
+TemplateAssemblerAMD64 >> addDoubleX1toX0 [
 	self assembleBytes: #[16rF2 16rF 16r58 16rC1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addSPtoT [
+TemplateAssemblerAMD64 >> addSPtoT [
 	self assembleBytes: #[16r48 16r1 16rE1].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> addSPwithImmediate: imm [
+TemplateAssemblerAMD64 >> addSPwithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16rC4];
@@ -43,31 +43,31 @@ TemplateAssembler64 >> addSPwithImmediate: imm [
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addSslotsToSP [
+TemplateAssemblerAMD64 >> addSslotsToSP [
 	self assembleBytes: #[16r48 16r8D 16r24 16rF4].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addTslotsToSP [
+TemplateAssemblerAMD64 >> addTslotsToSP [
 	self assembleBytes: #[16r48 16r8D 16r24 16rCC].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> addTtoR [
+TemplateAssemblerAMD64 >> addTtoR [
 	self assembleBytes: #[16r48 16r1 16rC8].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> andRwithA [
+TemplateAssemblerAMD64 >> andRwithA [
 	self assembleBytes: #[16r48 16r21 16rD0].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> andRwithImmediate: imm [
+TemplateAssemblerAMD64 >> andRwithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16rE0];
@@ -83,7 +83,7 @@ TemplateAssembler64 >> andRwithImmediate: imm [
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> andTosWithImmediate: imm [
+TemplateAssemblerAMD64 >> andTosWithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16r24 16r24];
@@ -99,61 +99,61 @@ TemplateAssembler64 >> andTosWithImmediate: imm [
 ]
 
 { #category : #private }
-TemplateAssembler64 >> buildFrame [
+TemplateAssemblerAMD64 >> buildFrame [
 	self assembleBytes: #[16r55 16r48 16r89 16rE5].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> callA [
+TemplateAssemblerAMD64 >> callA [
 	self assembleBytes: #[16rFF 16rD2].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> callIndirectA [
+TemplateAssemblerAMD64 >> callIndirectA [
 	self assembleBytes: #[16rFF 16r12].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> callR [
+TemplateAssemblerAMD64 >> callR [
 	self assembleBytes: #[16rFF 16rD0].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> clearAintegerBit [
+TemplateAssemblerAMD64 >> clearAintegerBit [
 	self assembleBytes: #[16r48 16rFF 16rCA].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> clearFPUFlags [
+TemplateAssemblerAMD64 >> clearFPUFlags [
 	self assembleBytes: #[16rDB 16rE2].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> clearRhighHalf [
+TemplateAssemblerAMD64 >> clearRhighHalf [
 	self assembleBytes: #[16r89 16rC0].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> clearRintegerBit [
+TemplateAssemblerAMD64 >> clearRintegerBit [
 	self assembleBytes: #[16r48 16rFF 16rC8].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> clearSafeRintegerBit [
+TemplateAssemblerAMD64 >> clearSafeRintegerBit [
 	self assembleBytes: #[16r24 16rFE].
 	
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> compareAwithImmediate: imm [
+TemplateAssemblerAMD64 >> compareAwithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16rFA];
@@ -169,25 +169,25 @@ TemplateAssembler64 >> compareAwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareEqualLargeX0withAindirect [
+TemplateAssemblerAMD64 >> compareEqualLargeX0withAindirect [
 	self assembleBytes: #[16rF2 16rF 16rC2 16r2 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareLessThanLargeX0withAindirect [
+TemplateAssemblerAMD64 >> compareLessThanLargeX0withAindirect [
 	self assembleBytes: #[16rF2 16rF 16rC2 16r2 16r1].
 	
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> compareRwithA [
+TemplateAssemblerAMD64 >> compareRwithA [
 	self assembleBytes: #[16r48 16r39 16rD0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareRwithEindex: index [
+TemplateAssemblerAMD64 >> compareRwithEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r3B 16r7]].
@@ -203,7 +203,7 @@ TemplateAssembler64 >> compareRwithEindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareRwithFPindex: index [
+TemplateAssemblerAMD64 >> compareRwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r3B 16r45 16r0]].
@@ -219,7 +219,7 @@ TemplateAssembler64 >> compareRwithFPindex: index [
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> compareRwithImmediate: imm [
+TemplateAssemblerAMD64 >> compareRwithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16rF8];
@@ -235,13 +235,13 @@ TemplateAssembler64 >> compareRwithImmediate: imm [
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> compareRwithS [
+TemplateAssemblerAMD64 >> compareRwithS [
 	self assembleBytes: #[16r48 16r39 16rF0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareRwithSindex: index [
+TemplateAssemblerAMD64 >> compareRwithSindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r3B 16r6]].
@@ -257,7 +257,7 @@ TemplateAssembler64 >> compareRwithSindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareRwithVindex: index [
+TemplateAssemblerAMD64 >> compareRwithVindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r49 16r3B 16r3]].
@@ -273,7 +273,7 @@ TemplateAssembler64 >> compareRwithVindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> compareSwithTindex: index [
+TemplateAssemblerAMD64 >> compareSwithTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r3B 16r31]].
@@ -289,7 +289,7 @@ TemplateAssembler64 >> compareSwithTindex: index [
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> compareTwithImmediate: imm [
+TemplateAssemblerAMD64 >> compareTwithImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16r83 16rF9];
@@ -305,138 +305,138 @@ TemplateAssembler64 >> compareTwithImmediate: imm [
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertAtoNativeInteger [
+TemplateAssemblerAMD64 >> convertAtoNativeInteger [
 	self assembleBytes: #[16r48 16rD1 16rFA].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertAtoSmallInteger [
+TemplateAssemblerAMD64 >> convertAtoSmallInteger [
 	self assembleBytes: #[16r48 16rD1 16rE2 16r48 16rFF 16rC2].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertRtoNativeInteger [
+TemplateAssemblerAMD64 >> convertRtoNativeInteger [
 	self assembleBytes: #[16r48 16rD1 16rF8].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertRtoSmallInteger [
+TemplateAssemblerAMD64 >> convertRtoSmallInteger [
 	self assembleBytes: #[16r48 16rD1 16rE0 16r48 16rFF 16rC0].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertTToNativeInteger [
+TemplateAssemblerAMD64 >> convertTToNativeInteger [
 	self assembleBytes: #[16r48 16rD1 16rF9].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertTosToSmallInteger [
+TemplateAssemblerAMD64 >> convertTosToSmallInteger [
 	self assembleBytes: #[16r48 16rD1 16r24 16r24 16r48 16rFF 16r4 16r24].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> convertTtoNativeInteger [
+TemplateAssemblerAMD64 >> convertTtoNativeInteger [
 	self assembleBytes: #[16r48 16rD1 16rF9].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> decR [
+TemplateAssemblerAMD64 >> decR [
 	self assembleBytes: #[16r48 16rFF 16rC8].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> decRindirect [
+TemplateAssemblerAMD64 >> decRindirect [
 	self assembleBytes: #[16r48 16rFF 16r8].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> divideDoubleX0byX1 [
+TemplateAssemblerAMD64 >> divideDoubleX0byX1 [
 	self assembleBytes: #[16rF2 16rF 16r5E 16rC1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> divideRbyT [
+TemplateAssemblerAMD64 >> divideRbyT [
 	self assembleBytes: #[16r48 16r99 16r48 16rF7 16rF9].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> dropTopOfFPU [
+TemplateAssemblerAMD64 >> dropTopOfFPU [
 	self assembleBytes: #[16rDD 16rD8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> dummyPointer [
+TemplateAssemblerAMD64 >> dummyPointer [
 	^16r1BADADD01BADADD0
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> ensureRintegerBit [
+TemplateAssemblerAMD64 >> ensureRintegerBit [
 	self assembleBytes: #[16rC 16r1].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> ensureSafeRintegerBit [
+TemplateAssemblerAMD64 >> ensureSafeRintegerBit [
 	self assembleBytes: #[16rC 16r1].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> exchangeRindirectWithT [
+TemplateAssemblerAMD64 >> exchangeRindirectWithT [
 	self assembleBytes: #[16r48 16r87 16r8].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> incA [
+TemplateAssemblerAMD64 >> incA [
 	self assembleBytes: #[16r48 16rFF 16rC2].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> incC [
+TemplateAssemblerAMD64 >> incC [
 	self assembleBytes: #[16r48 16rFF 16rC3].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> initializeS [
+TemplateAssemblerAMD64 >> initializeS [
 	self assembleBytes: #[16r48 16r89 16rC6].
 	
 ]
 
 { #category : #private }
-TemplateAssembler64 >> jumpIndirectA [
+TemplateAssemblerAMD64 >> jumpIndirectA [
 	self assembleBytes: #[16rFF 16r22].
 	
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> jumpToA [
+TemplateAssemblerAMD64 >> jumpToA [
 	self assembleBytes: #[16rFF 16rE2].
 	
 ]
 
 { #category : #comparing }
-TemplateAssembler64 >> jumpToS [
+TemplateAssemblerAMD64 >> jumpToS [
 	self assembleBytes: #[16rFF 16rE6].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> jumpToTindex: index [
+TemplateAssemblerAMD64 >> jumpToTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16rFF 16r21]].
@@ -452,7 +452,7 @@ TemplateAssembler64 >> jumpToTindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithAindex: index [
+TemplateAssemblerAMD64 >> loadAwithAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r12]].
@@ -468,7 +468,7 @@ TemplateAssembler64 >> loadAwithAindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithEindex: index [
+TemplateAssemblerAMD64 >> loadAwithEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r17]].
@@ -484,7 +484,7 @@ TemplateAssembler64 >> loadAwithEindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithFPindex: index [
+TemplateAssemblerAMD64 >> loadAwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r55 16r0]].
@@ -500,12 +500,12 @@ TemplateAssembler64 >> loadAwithFPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithFalse [
+TemplateAssemblerAMD64 >> loadAwithFalse [
 	self assembleBytes: #[16r4C 16r89 16rF2]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadAwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16rC7 16rC2];
@@ -516,18 +516,18 @@ TemplateAssembler64 >> loadAwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithNil [
+TemplateAssemblerAMD64 >> loadAwithNil [
 	self assembleBytes: #[16r4C 16r89 16rE2]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithR [
+TemplateAssemblerAMD64 >> loadAwithR [
 	self assembleBytes: #[16r48 16r89 16rC2].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithRindex: index [
+TemplateAssemblerAMD64 >> loadAwithRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r10]].
@@ -543,19 +543,19 @@ TemplateAssembler64 >> loadAwithRindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithRoffsetAtA [
+TemplateAssemblerAMD64 >> loadAwithRoffsetAtA [
 	self assembleBytes: #[16r48 16r8B 16r14 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithS [
+TemplateAssemblerAMD64 >> loadAwithS [
 	self assembleBytes: #[16r48 16r89 16rF2].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithSindex: index [
+TemplateAssemblerAMD64 >> loadAwithSindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r16]].
@@ -571,24 +571,24 @@ TemplateAssembler64 >> loadAwithSindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithT [
+TemplateAssemblerAMD64 >> loadAwithT [
 	self assembleBytes: #[16r48 16r89 16rCA].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadAwithTrue [
+TemplateAssemblerAMD64 >> loadAwithTrue [
 	self assembleBytes: #[16r4C 16r89 16rEA]
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadEwithAddressOfRatA [
+TemplateAssemblerAMD64 >> loadEwithAddressOfRatA [
 	self assembleBytes: #[16r48 16r8D 16r7C 16rD0 16rF8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadEwithFPindex: index [
+TemplateAssemblerAMD64 >> loadEwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r7D 16r0]].
@@ -604,7 +604,7 @@ TemplateAssembler64 >> loadEwithFPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadEwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadEwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16rC7 16rC7];
@@ -615,90 +615,90 @@ TemplateAssembler64 >> loadEwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadEwithR [
+TemplateAssemblerAMD64 >> loadEwithR [
 	self assembleBytes: #[16r48 16r89 16rC7].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadFPwithR [
+TemplateAssemblerAMD64 >> loadFPwithR [
 	self assembleBytes: #[16r48 16r89 16rC5].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadFPwithSP [
+TemplateAssemblerAMD64 >> loadFPwithSP [
 	self assembleBytes: #[16r48 16r89 16rE5].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadLargeX0withRindirect [
+TemplateAssemblerAMD64 >> loadLargeX0withRindirect [
 	self assembleBytes: #[16r66 16r48 16rF 16r6E 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadLargeX1withAindirect [
+TemplateAssemblerAMD64 >> loadLargeX1withAindirect [
 	self assembleBytes: #[16r66 16r48 16rF 16r6E 16rA].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadLongRWithRAtOffsetA [
+TemplateAssemblerAMD64 >> loadLongRWithRAtOffsetA [
 	self assembleBytes: #[16r8B 16r4 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadLongRwithRatOffsetA [
+TemplateAssemblerAMD64 >> loadLongRwithRatOffsetA [
 	self assembleBytes: #[16r8B 16r4 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadMXCSRfromA [
+TemplateAssemblerAMD64 >> loadMXCSRfromA [
 	self assembleBytes: #[16rF 16rAE 16r12].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> loadMwithA [
+TemplateAssemblerAMD64 >> loadMwithA [
 	self assembleBytes: #[16r48 16r89 16rD3]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRConvertingDoubleRindirect [
+TemplateAssemblerAMD64 >> loadRConvertingDoubleRindirect [
 	self assembleBytes: #[16rF2 16r48 16rF 16r2C 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRconvertingDoublePointedByR [
+TemplateAssemblerAMD64 >> loadRconvertingDoublePointedByR [
 	self assembleBytes: #[16rF2 16r48 16rF 16r2C 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithA [
+TemplateAssemblerAMD64 >> loadRwithA [
 	self assembleBytes: #[16r48 16r89 16rD0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithArgPointer [
+TemplateAssemblerAMD64 >> loadRwithArgPointer [
 	self assembleBytes: #[16r48 16r8D 16r45 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithE [
+TemplateAssemblerAMD64 >> loadRwithE [
 	self assembleBytes: #[16r48 16r89 16rF8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithEindex: index [
+TemplateAssemblerAMD64 >> loadRwithEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r7]].
@@ -714,13 +714,13 @@ TemplateAssembler64 >> loadRwithEindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithFP [
+TemplateAssemblerAMD64 >> loadRwithFP [
 	self assembleBytes: #[16r48 16r89 16rE8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithFPindex: index [
+TemplateAssemblerAMD64 >> loadRwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r45 16r0]].
@@ -736,12 +736,12 @@ TemplateAssembler64 >> loadRwithFPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithFalse [
+TemplateAssemblerAMD64 >> loadRwithFalse [
 	self assembleBytes: #[16r4C 16r89 16rF0]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadRwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16rC7 16rC0];
@@ -752,12 +752,12 @@ TemplateAssembler64 >> loadRwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithM [
+TemplateAssemblerAMD64 >> loadRwithM [
 	self assembleBytes: #[16r48 16r89 16rD8]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithMindex: index [
+TemplateAssemblerAMD64 >> loadRwithMindex: index [
 	| offset |
 	offset := (index - 1) * wordSize.
 	offset = 0
@@ -772,24 +772,24 @@ TemplateAssembler64 >> loadRwithMindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithNil [
+TemplateAssemblerAMD64 >> loadRwithNil [
 	self assembleBytes: #[16r4C 16r89 16rE0]
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadRwithRatA [
+TemplateAssemblerAMD64 >> loadRwithRatA [
 	self assembleBytes: #[16r48 16r8B 16r44 16rD0 16rF8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithRatOffsetA [
+TemplateAssemblerAMD64 >> loadRwithRatOffsetA [
 	self assembleBytes: #[16r48 16r8B 16r4 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithRindex: index [
+TemplateAssemblerAMD64 >> loadRwithRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r0]].
@@ -805,13 +805,13 @@ TemplateAssembler64 >> loadRwithRindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithS [
+TemplateAssemblerAMD64 >> loadRwithS [
 	self assembleBytes: #[16r48 16r89 16rF0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithSPindex: index [
+TemplateAssemblerAMD64 >> loadRwithSPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r4 16r24]].
@@ -827,7 +827,7 @@ TemplateAssembler64 >> loadRwithSPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithSindex: index [
+TemplateAssemblerAMD64 >> loadRwithSindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r6]].
@@ -843,25 +843,25 @@ TemplateAssembler64 >> loadRwithSindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithT [
+TemplateAssemblerAMD64 >> loadRwithT [
 	self assembleBytes: #[16r48 16r89 16rC8].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> loadRwithTIBatIndexR [
+TemplateAssemblerAMD64 >> loadRwithTIBatIndexR [
 	self assembleBytes: #[16r65 16r48 16r8B 16r4 16rC5 16r0 16r0 16r0 16r0].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> loadRwithThreadVariableAtIndexR [
+TemplateAssemblerAMD64 >> loadRwithThreadVariableAtIndexR [
 	self assembleBytes: #[16r65 16r48 16r8B 16r4 16rC5 16r80 16r14 16r0 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithTindex: index [
+TemplateAssemblerAMD64 >> loadRwithTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r1]].
@@ -877,48 +877,48 @@ TemplateAssembler64 >> loadRwithTindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithTos [
+TemplateAssemblerAMD64 >> loadRwithTos [
 	self assembleBytes: #[16r48 16r8B 16r4 16r24].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithTrue [
+TemplateAssemblerAMD64 >> loadRwithTrue [
 	self assembleBytes: #[16r4C 16r89 16rE8]
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadRwithX0 [
+TemplateAssemblerAMD64 >> loadRwithX0 [
 	self assembleBytes: #[16r66 16r48 16rF 16r7E 16rC0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSPwithFP [
+TemplateAssemblerAMD64 >> loadSPwithFP [
 	self assembleBytes: #[16r48 16r89 16rEC].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSPwithT [
+TemplateAssemblerAMD64 >> loadSPwithT [
 	self assembleBytes: #[16r48 16r89 16rCC].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSwithA [
+TemplateAssemblerAMD64 >> loadSwithA [
 	self assembleBytes: #[16r48 16r89 16rD6].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadSwithAddressOfSatA [
+TemplateAssemblerAMD64 >> loadSwithAddressOfSatA [
 	self assembleBytes: #[16r48 16r8D 16r74 16rD6 16rF8].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSwithFPindex: index [
+TemplateAssemblerAMD64 >> loadSwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r75 16r0]].
@@ -934,7 +934,7 @@ TemplateAssembler64 >> loadSwithFPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadSwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16rC7 16rC6];
@@ -945,7 +945,7 @@ TemplateAssembler64 >> loadSwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSwithRindex: index [
+TemplateAssemblerAMD64 >> loadSwithRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r30]].
@@ -961,19 +961,19 @@ TemplateAssembler64 >> loadSwithRindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadSwithT [
+TemplateAssemblerAMD64 >> loadSwithT [
 	self assembleBytes: #[16r48 16r89 16rCE].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithA [
+TemplateAssemblerAMD64 >> loadTwithA [
 	self assembleBytes: #[16r48 16r89 16rD1].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithAindex: index [
+TemplateAssemblerAMD64 >> loadTwithAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16rA]].
@@ -989,7 +989,7 @@ TemplateAssembler64 >> loadTwithAindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithEindex: index [
+TemplateAssemblerAMD64 >> loadTwithEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16rF]].
@@ -1005,7 +1005,7 @@ TemplateAssembler64 >> loadTwithEindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithFPindex: index [
+TemplateAssemblerAMD64 >> loadTwithFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r4D 16r0]].
@@ -1021,7 +1021,7 @@ TemplateAssembler64 >> loadTwithFPindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadTwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r48 16rC7 16rC1];
@@ -1032,13 +1032,13 @@ TemplateAssembler64 >> loadTwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithR [
+TemplateAssemblerAMD64 >> loadTwithR [
 	self assembleBytes: #[16r48 16r89 16rC1].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadTwithTindex: index [
+TemplateAssemblerAMD64 >> loadTwithTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r8B 16r9]].
@@ -1054,7 +1054,7 @@ TemplateAssembler64 >> loadTwithTindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadVwithImmediate: imm [
+TemplateAssemblerAMD64 >> loadVwithImmediate: imm [
 	(-16r80000000 <= imm and: [ imm < 16r80000000 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r49 16rC7 16rC3];
@@ -1065,145 +1065,145 @@ TemplateAssembler64 >> loadVwithImmediate: imm [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadX0withRasDouble [
+TemplateAssemblerAMD64 >> loadX0withRasDouble [
 	self assembleBytes: #[16rF2 16r48 16rF 16r2A 16rC0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> loadX1roundingX0 [
+TemplateAssemblerAMD64 >> loadX1roundingX0 [
 	self assembleBytes: #[16r66 16rF 16r3A 16rB 16rC8 16r3].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadZeroExtendByteRwithRatA [
+TemplateAssemblerAMD64 >> loadZeroExtendByteRwithRatA [
 	self assembleBytes: #[16r48 16rF 16rB6 16r44 16r10 16rFF].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadZeroExtendByteRwithSPatA [
+TemplateAssemblerAMD64 >> loadZeroExtendByteRwithSPatA [
 	self assembleBytes: #[16r48 16rF 16rB6 16r44 16r14 16rFF].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> loadZeroExtendLongRwithRatA [
+TemplateAssemblerAMD64 >> loadZeroExtendLongRwithRatA [
 	self assembleBytes: #[16r8B 16r44 16r90 16rFC].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> lock [
+TemplateAssemblerAMD64 >> lock [
 	self assembleBytes: #[16rF0].
 	
 ]
 
 { #category : #'opcodes - integer related' }
-TemplateAssembler64 >> moveTslots [
+TemplateAssemblerAMD64 >> moveTslots [
 	self assembleBytes: #[16rF3 16r48 16rA5].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> multiplyDoubleX0byX1 [
+TemplateAssemblerAMD64 >> multiplyDoubleX0byX1 [
 	self assembleBytes: #[16rF2 16rF 16r59 16rC1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> multiplyRbyA [
+TemplateAssemblerAMD64 >> multiplyRbyA [
 	self assembleBytes: #[16r48 16rF7 16rEA].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> orRwithA [
+TemplateAssemblerAMD64 >> orRwithA [
 	self assembleBytes: #[16r48 16r9 16rD0].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popA [
+TemplateAssemblerAMD64 >> popA [
 	self assembleBytes: #[16r5A].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popB [
+TemplateAssemblerAMD64 >> popB [
 	self assembleBytes: #[16r5B].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popE [
+TemplateAssemblerAMD64 >> popE [
 	self assembleBytes: #[16r5F].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popFP [
+TemplateAssemblerAMD64 >> popFP [
 	self assembleBytes: #[16r5D].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popR [
+TemplateAssemblerAMD64 >> popR [
 	self assembleBytes: #[16r58].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popS [
+TemplateAssemblerAMD64 >> popS [
 	self assembleBytes: #[16r5E].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popSP [
+TemplateAssemblerAMD64 >> popSP [
 	self assembleBytes: #[16r5C].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popSPindirect [
+TemplateAssemblerAMD64 >> popSPindirect [
 	self assembleBytes: #[16r8F 16r4 16r24].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> popT [
+TemplateAssemblerAMD64 >> popT [
 	self assembleBytes: #[16r59].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushA [
+TemplateAssemblerAMD64 >> pushA [
 	self assembleBytes: #[16r52].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> pushAOnFPUStack [
+TemplateAssemblerAMD64 >> pushAOnFPUStack [
 	self assembleBytes: #[16rDD 16r2].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushB [
+TemplateAssemblerAMD64 >> pushB [
 	self assembleBytes: #[16r53].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushE [
+TemplateAssemblerAMD64 >> pushE [
 	self assembleBytes: #[16r57].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushEindex: index [
+TemplateAssemblerAMD64 >> pushEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16rFF 16r37]].
@@ -1219,13 +1219,13 @@ TemplateAssembler64 >> pushEindex: index [
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushFP [
+TemplateAssemblerAMD64 >> pushFP [
 	self assembleBytes: #[16r55].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushFPindex: index [
+TemplateAssemblerAMD64 >> pushFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16rFF 16r75 16r0]].
@@ -1241,7 +1241,7 @@ TemplateAssembler64 >> pushFPindex: index [
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushImmediate: imm [
+TemplateAssemblerAMD64 >> pushImmediate: imm [
 	(-128 <= imm and: [ imm < 128 ])
 		ifTrue: [ ^ self
 				assembleBytes: #[16r6A];
@@ -1257,37 +1257,37 @@ TemplateAssembler64 >> pushImmediate: imm [
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushIndirectR [
+TemplateAssemblerAMD64 >> pushIndirectR [
 	self assembleBytes: #[16rFF 16r30].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushR [
+TemplateAssemblerAMD64 >> pushR [
 	self assembleBytes: #[16r50].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> pushROnFPUStack [
+TemplateAssemblerAMD64 >> pushROnFPUStack [
 	self assembleBytes: #[16rDD 16r0].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushS [
+TemplateAssemblerAMD64 >> pushS [
 	self assembleBytes: #[16r56].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushSP [
+TemplateAssemblerAMD64 >> pushSP [
 	self assembleBytes: #[16r54].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushSindex: index [
+TemplateAssemblerAMD64 >> pushSindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16rFF 16r36]].
@@ -1303,13 +1303,13 @@ TemplateAssembler64 >> pushSindex: index [
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushT [
+TemplateAssemblerAMD64 >> pushT [
 	self assembleBytes: #[16r51].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushTindex: index [
+TemplateAssemblerAMD64 >> pushTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16rFF 16r31]].
@@ -1325,7 +1325,7 @@ TemplateAssembler64 >> pushTindex: index [
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> pushVindex: index [
+TemplateAssemblerAMD64 >> pushVindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r41 16rFF 16r33]].
@@ -1341,84 +1341,84 @@ TemplateAssembler64 >> pushVindex: index [
 ]
 
 { #category : #epilogue }
-TemplateAssembler64 >> restoreCallerEnvironment [
+TemplateAssemblerAMD64 >> restoreCallerEnvironment [
 	self assembleBytes: #[16r48 16r8B 16r7D 16rE8].
 	
 ]
 
 { #category : #epilogue }
-TemplateAssembler64 >> restoreCallerFrame [
+TemplateAssemblerAMD64 >> restoreCallerFrame [
 	self assembleBytes: #[16r48 16r89 16rEC 16r5D].
 	
 ]
 
 { #category : #epilogue }
-TemplateAssembler64 >> restoreCallerM [
+TemplateAssemblerAMD64 >> restoreCallerM [
 	self assembleBytes: #[16r48 16r8B 16r5D 16rF0]
 ]
 
 { #category : #epilogue }
-TemplateAssembler64 >> restoreCallerSelf [
+TemplateAssemblerAMD64 >> restoreCallerSelf [
 	self assembleBytes: #[16r48 16r8B 16r75 16rF8].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> restoreRSmallInteger [
+TemplateAssemblerAMD64 >> restoreRSmallInteger [
 	self assembleBytes: #[16r48 16rD1 16rD0].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> restoreRsmallInteger [
+TemplateAssemblerAMD64 >> restoreRsmallInteger [
 	self assembleBytes: #[16r48 16rD1 16rD0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> saveCallerFrame [
+TemplateAssemblerAMD64 >> saveCallerFrame [
 	self assembleBytes: #[16r55 16r48 16r89 16rE5].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> scaleFloatOnRWithA [
+TemplateAssemblerAMD64 >> scaleFloatOnRWithA [
 	self assembleBytes: #[16rDD 16r2 16rDD 16r0 16rD9 16rFD 16rDD 16r18 16rDD 16rD8].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> shiftLeftRwithT [
+TemplateAssemblerAMD64 >> shiftLeftRwithT [
 	self assembleBytes: #[16r48 16rD3 16rE0].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> shiftRightRwithT [
+TemplateAssemblerAMD64 >> shiftRightRwithT [
 	self assembleBytes: #[16r48 16rD3 16rF8].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> sqrtDoubleX0 [
+TemplateAssemblerAMD64 >> sqrtDoubleX0 [
 	self assembleBytes: #[16rF2 16rF 16r51 16rC0].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeAinSPatT [
+TemplateAssemblerAMD64 >> storeAinSPatT [
 	self assembleBytes: #[16r48 16r89 16r54 16rCC 16rF8].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeAinThreadVariableAtIndexR [
+TemplateAssemblerAMD64 >> storeAinThreadVariableAtIndexR [
 	self assembleBytes: #[16r65 16r48 16r89 16r14 16rC5 16r80 16r14 16r0 16r0].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeAinTindex: index [
+TemplateAssemblerAMD64 >> storeAinTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r11]].
@@ -1434,25 +1434,25 @@ TemplateAssembler64 >> storeAinTindex: index [
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> storeArgumentsInStack [
+TemplateAssemblerAMD64 >> storeArgumentsInStack [
 	self assembleBytes: #[16r48 16r89 16r4D 16r10 16r48 16r89 16r55 16r18 16r4C 16r89 16r45 16r20 16r4C 16r89 16r4D 16r28].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeByteTinRatA [
+TemplateAssemblerAMD64 >> storeByteTinRatA [
 	self assembleBytes: #[16r88 16r4C 16r10 16rFF].
 	
 ]
 
 { #category : #'push/pop' }
-TemplateAssembler64 >> storeDoubleResultInRindirect [
+TemplateAssemblerAMD64 >> storeDoubleResultInRindirect [
 	self assembleBytes: #[16r66 16r48 16rF 16r7E 16r0].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeEinAindex: index [
+TemplateAssemblerAMD64 >> storeEinAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r3A]].
@@ -1468,7 +1468,7 @@ TemplateAssembler64 >> storeEinAindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeEinRindex: index [
+TemplateAssemblerAMD64 >> storeEinRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r38]].
@@ -1484,49 +1484,49 @@ TemplateAssembler64 >> storeEinRindex: index [
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> storeLargeX0inA [
+TemplateAssemblerAMD64 >> storeLargeX0inA [
 	self assembleBytes: #[16r66 16r48 16rF 16r7E 16r2].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> storeLargeX0inR [
+TemplateAssemblerAMD64 >> storeLargeX0inR [
 	self assembleBytes: #[16r66 16r48 16rF 16r7E 16r0].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> storeLargeX0inT [
+TemplateAssemblerAMD64 >> storeLargeX0inT [
 	self assembleBytes: #[16r66 16r48 16rF 16r7E 16r1].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeLongTInRAtA [
+TemplateAssemblerAMD64 >> storeLongTInRAtA [
 	self assembleBytes: #[16r89 16r4C 16r90 16rFC].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeLongTinRatA [
+TemplateAssemblerAMD64 >> storeLongTinRatA [
 	self assembleBytes: #[16r89 16r4C 16r90 16rFC].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeLongTinRatOffsetA [
+TemplateAssemblerAMD64 >> storeLongTinRatOffsetA [
 	self assembleBytes: #[16r89 16rC 16r10].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> storeMXCSRintoA [
+TemplateAssemblerAMD64 >> storeMXCSRintoA [
 	self assembleBytes: #[16rF 16rAE 16r1A].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeRinAindex: index [
+TemplateAssemblerAMD64 >> storeRinAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r2]].
@@ -1542,7 +1542,7 @@ TemplateAssembler64 >> storeRinAindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeRinEindex: index [
+TemplateAssemblerAMD64 >> storeRinEindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r7]].
@@ -1558,7 +1558,7 @@ TemplateAssembler64 >> storeRinEindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeRinFPindex: index [
+TemplateAssemblerAMD64 >> storeRinFPindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r45 16r0]].
@@ -1574,7 +1574,7 @@ TemplateAssembler64 >> storeRinFPindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeRinSindex: index [
+TemplateAssemblerAMD64 >> storeRinSindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r6]].
@@ -1590,7 +1590,7 @@ TemplateAssembler64 >> storeRinSindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeRinTindex: index [
+TemplateAssemblerAMD64 >> storeRinTindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r1]].
@@ -1606,13 +1606,13 @@ TemplateAssembler64 >> storeRinTindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeShortTinRatOffsetA [
+TemplateAssemblerAMD64 >> storeShortTinRatOffsetA [
 	self assembleBytes: #[16r66 16r89 16rC 16r10].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeSinAindex: index [
+TemplateAssemblerAMD64 >> storeSinAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r32]].
@@ -1628,7 +1628,7 @@ TemplateAssembler64 >> storeSinAindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeSinRindex: index [
+TemplateAssemblerAMD64 >> storeSinRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r30]].
@@ -1644,19 +1644,19 @@ TemplateAssembler64 >> storeSinRindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTIBwithAatIndexR [
+TemplateAssemblerAMD64 >> storeTIBwithAatIndexR [
 	self assembleBytes: #[16r65 16r48 16r89 16r14 16rC5 16r0 16r0 16r0 16r0].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTInRAtA [
+TemplateAssemblerAMD64 >> storeTInRAtA [
 	self assembleBytes: #[16r48 16r89 16r4C 16rD0 16rF8].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTinAindex: index [
+TemplateAssemblerAMD64 >> storeTinAindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16rA]].
@@ -1672,19 +1672,19 @@ TemplateAssembler64 >> storeTinAindex: index [
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTinRatA [
+TemplateAssemblerAMD64 >> storeTinRatA [
 	self assembleBytes: #[16r48 16r89 16r4C 16rD0 16rF8].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTinRatOffsetA [
+TemplateAssemblerAMD64 >> storeTinRatOffsetA [
 	self assembleBytes: #[16r48 16r89 16rC 16r10].
 	
 ]
 
 { #category : #storing }
-TemplateAssembler64 >> storeTinRindex: index [
+TemplateAssemblerAMD64 >> storeTinRindex: index [
 	| offset |
 	offset := index - 1 * wordSize.
 	offset = 0 ifTrue: [^self assembleBytes: #[16r48 16r89 16r8]].
@@ -1700,85 +1700,85 @@ TemplateAssembler64 >> storeTinRindex: index [
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> subAfromR [
+TemplateAssemblerAMD64 >> subAfromR [
 	self assembleBytes: #[16r48 16r29 16rD0].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> subAfromT [
+TemplateAssemblerAMD64 >> subAfromT [
 	self assembleBytes: #[16r48 16r29 16rD1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> subDoubleX1fromX0 [
+TemplateAssemblerAMD64 >> subDoubleX1fromX0 [
 	self assembleBytes: #[16rF2 16rF 16r5C 16rC1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> subTslotsToSP [
+TemplateAssemblerAMD64 >> subTslotsToSP [
 	self assembleBytes: #[16r48 16rF7 16rD9 16r48 16r8D 16r24 16rCC 16r48 16rF7 16rD9].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> testAintegerBit [
+TemplateAssemblerAMD64 >> testAintegerBit [
 	self assembleBytes: #[16rF6 16rC2 16r1].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> testRintegerBit [
+TemplateAssemblerAMD64 >> testRintegerBit [
 	self assembleBytes: #[16rA8 16r1].
 	
 ]
 
 { #category : #loading }
-TemplateAssembler64 >> testRwithR [
+TemplateAssemblerAMD64 >> testRwithR [
 	self assembleBytes: #[16r48 16r85 16rC0].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> testTIntegerBit [
+TemplateAssemblerAMD64 >> testTIntegerBit [
 	self assembleBytes: #[16rF6 16rC1 16r1].
 	
 ]
 
 { #category : #integers }
-TemplateAssembler64 >> testTintegerBit [
+TemplateAssemblerAMD64 >> testTintegerBit [
 	self assembleBytes: #[16rF6 16rC1 16r1].
 	
 ]
 
 { #category : #arithmetic }
-TemplateAssembler64 >> wordSize: anInteger [
+TemplateAssemblerAMD64 >> wordSize: anInteger [
 	self ASSERT: anInteger = 8.
 	super wordSize: anInteger
 ]
 
 { #category : #'opcodes - integer related' }
-TemplateAssembler64 >> writeTslots [
+TemplateAssemblerAMD64 >> writeTslots [
 	self assembleBytes: #[16rF3 16r48 16rAB].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> xorAwithR [
+TemplateAssemblerAMD64 >> xorAwithR [
 	self assembleBytes: #[16r48 16r31 16rC2].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> xorFPwithFP [
+TemplateAssemblerAMD64 >> xorFPwithFP [
 	self assembleBytes: #[16r48 16r31 16rED].
 	
 ]
 
 { #category : #logic }
-TemplateAssembler64 >> xorRwithA [
+TemplateAssemblerAMD64 >> xorRwithA [
 	self assembleBytes: #[16r48 16r31 16rD0].
 	
 ]

--- a/bootstrap/src/Powerlang-Core/X64ABI.class.st
+++ b/bootstrap/src/Powerlang-Core/X64ABI.class.st
@@ -5,6 +5,9 @@ Copyright (c) 2020 Aucerna.
 Class {
 	#name : #X64ABI,
 	#superclass : #ABI,
+	#pools : [
+		'Registers'
+	],
 	#category : #'Powerlang-Core-Assembler-Intel'
 }
 

--- a/bootstrap/src/Powerlang-Core/X86ABI.class.st
+++ b/bootstrap/src/Powerlang-Core/X86ABI.class.st
@@ -5,6 +5,9 @@ Copyright (c) 2020 Aucerna.
 Class {
 	#name : #X86ABI,
 	#superclass : #ABI,
+	#pools : [
+		'Registers'
+	],
 	#category : #'Powerlang-Core-Assembler-Intel'
 }
 

--- a/bootstrap/src/Powerlang-Tests/JITAssemblerAMD64Test.class.st
+++ b/bootstrap/src/Powerlang-Tests/JITAssemblerAMD64Test.class.st
@@ -1,0 +1,6233 @@
+Class {
+	#name : #JITAssemblerAMD64Test,
+	#superclass : #TestCase,
+	#instVars : [
+		'assembler'
+	],
+	#category : #'Powerlang-Tests-Assembler-JIT'
+}
+
+{ #category : #utilities }
+JITAssemblerAMD64Test class >> generateTest: aMessage [
+	| assembler bytes testSelector source |
+
+	"  For now, only handle messages with zero or more INTEGER arguments"
+	(aMessage arguments allSatisfy: [:e | e isInteger ]) ifFalse: [ ^ self ].
+
+	assembler := JITAssemblerAMD64 new wordSize: 8.
+	[ 
+		aMessage sendTo: assembler.
+		bytes := assembler bytes.
+		bytes isEmpty ifTrue:[ ^ self ].
+	] on: Error do:[ ^self ].
+
+	testSelector := String streamContents: [ :s|
+		s nextPutAll: 'test'.
+		s nextPutAll: (aMessage selector capitalized copyReplaceAll: $: with: $_).
+		aMessage arguments notEmpty ifTrue: [ 
+			aMessage arguments do: [:e | 
+				s nextPut: $_.
+				s nextPutAll: (e printString replaceAll: $- with: $m).
+			].
+		].
+	].
+
+	source := '<1s>
+	
+	assembler perform: <2s> withArguments: <3s>.
+	self 
+		assert: (assembler bytes)
+		equals: (<4s>)
+	' expandMacrosWith: testSelector
+				  with: aMessage selector storeString
+				  with: aMessage arguments storeString
+				  with: bytes storeString.
+	
+	self compile: source classified: #'tests - generated 2'
+	
+	"
+	self generateTests
+	"
+
+]
+
+{ #category : #utilities }
+JITAssemblerAMD64Test class >> generateTests [
+	"JITAssemblerAMD64 selectorsDo: [ :sel | sel isUnary ifTrue:[ self generateTest: sel ] ]."
+
+	| messages |
+
+	JITAssemblerAMD64 class 
+			compile: 'new ^ MessageCollector for: super new' 
+			classified: #'temporary'.
+	[ 
+		MessageCollector messages removeAll.
+		KernelBuilderTest new setUp; test400completeNativizedSegmentWithBase.
+		messages := MessageCollector messages copy.
+		MessageCollector messages copy.
+	] ensure: [ 
+		MessageCollector messages removeAll.
+		JITAssemblerAMD64 class removeSelector: #new.
+	].
+
+	self halt.    
+	messages do: [:message | self generateTest: message ].
+
+]
+
+{ #category : #running }
+JITAssemblerAMD64Test >> setUp [
+	super setUp.
+	assembler := JITAssemblerAMD64 new wordSize: 8.
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddAtoR [
+	
+	assembler perform: #addAtoR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 1 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddDoubleX1toX0 [
+	
+	assembler perform: #addDoubleX1toX0 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 88 193])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddRconstant__1 [
+	
+	assembler perform: #addRconstant: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 192 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddRconstant__2 [
+	
+	assembler perform: #addRconstant: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 192 2])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddRconstant__4 [
+	
+	assembler perform: #addRconstant: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 192 4])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddRconstant__8 [
+	
+	assembler perform: #addRconstant: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 192 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddRconstant__m2 [
+	
+	assembler perform: #addRconstant: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 192 254])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testAddSPtoT [
+	
+	assembler addSPtoT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 1 225])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testAddSslotsToSP [
+	
+	assembler addSslotsToSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 141 36 244])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddToTconstant__1 [
+	
+	assembler perform: #addToTconstant: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 193 1])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testAddTslotsToSP [
+	
+	assembler addTslotsToSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 141 36 204])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAddTtoR [
+	
+	assembler perform: #addTtoR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 1 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAlignTo__16 [
+	
+	assembler perform: #alignTo: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[144])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testAndRwithA [
+	
+	assembler perform: #andRwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 33 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testBreakpoint [
+	
+	assembler perform: #breakpoint withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[204])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testBuildFrame [
+	
+	assembler perform: #buildFrame withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[85 72 137 229])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testCallA [
+	
+	assembler callA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 210])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCallIndirectA [
+	
+	assembler perform: #callIndirectA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 18])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCallIndirectM [
+	
+	assembler perform: #callIndirectM withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 19])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testCallR [
+	
+	assembler callR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 208])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testClearAintegerBit [
+	
+	assembler clearAintegerBit.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 202])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testClearFPUFlags [
+	
+	assembler perform: #clearFPUFlags withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[219 226])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testClearRhighHalf [
+	
+	assembler clearRhighHalf.
+	self 
+		assert: (assembler bytes)
+		equals: (#[137 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testClearRintegerBit [
+	
+	assembler perform: #clearRintegerBit withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testClearSafeRintegerBit [
+	
+	assembler perform: #clearSafeRintegerBit withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[36 254])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testCompareAwithFalse [
+	
+	assembler compareAwithFalse.
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 57 242])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testCompareAwithTrue [
+	
+	assembler compareAwithTrue.
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 57 234])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareEqualLargeX0withAindirect [
+	
+	assembler perform: #compareEqualLargeX0withAindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 194 2 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareLessThanLargeX0withAindirect [
+	
+	assembler perform: #compareLessThanLargeX0withAindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 194 2 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithA [
+	
+	assembler perform: #compareRwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 57 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithFalse [
+	
+	assembler perform: #compareRwithFalse withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 57 240])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithImmediate__0 [
+	
+	assembler perform: #compareRwithImmediate: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 248 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithNil [
+	
+	assembler perform: #compareRwithNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 57 224])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testCompareRwithS [
+	
+	assembler compareRwithS.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 57 240])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithSmallInteger__0 [
+	
+	assembler perform: #compareRwithSmallInteger: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 248 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareRwithTrue [
+	
+	assembler perform: #compareRwithTrue withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 57 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__1 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 49])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__11 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 80])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__13 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 96])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__3 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__5 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__7 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareSwithTindex__9 [
+	
+	assembler perform: #compareSwithTindex: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 59 113 64])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareTwithA [
+	
+	assembler perform: #compareTwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 57 209])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testCompareTwithImmediate__0 [
+	
+	assembler perform: #compareTwithImmediate: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 249 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testConvertAtoNativeInteger [
+	
+	assembler perform: #convertAtoNativeInteger withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 250])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testConvertAtoSmallInteger [
+	
+	assembler convertAtoSmallInteger.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 226 72 255 194])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testConvertRtoNativeInteger [
+	
+	assembler perform: #convertRtoNativeInteger withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testConvertRtoSmallInteger [
+	
+	assembler perform: #convertRtoSmallInteger withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 224 72 255 192])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testConvertTToNativeInteger [
+	
+	assembler convertTToNativeInteger.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 249])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testConvertTosToSmallInteger [
+	
+	assembler convertTosToSmallInteger.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 36 36 72 255 4 36])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testConvertTtoNativeInteger [
+	
+	assembler perform: #convertTtoNativeInteger withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 249])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testDecR [
+	
+	assembler decR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDecRindirect [
+	
+	assembler perform: #decRindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__1 [
+	
+	assembler perform: #discardArguments: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__2 [
+	
+	assembler perform: #discardArguments: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__3 [
+	
+	assembler perform: #discardArguments: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__4 [
+	
+	assembler perform: #discardArguments: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__5 [
+	
+	assembler perform: #discardArguments: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__6 [
+	
+	assembler perform: #discardArguments: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDiscardArguments__7 [
+	
+	assembler perform: #discardArguments: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 56])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDivideDoubleX0byX1 [
+	
+	assembler perform: #divideDoubleX0byX1 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 94 193])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDivideRbyT [
+	
+	assembler perform: #divideRbyT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 153 72 247 249])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testDropTopOfFPU [
+	
+	assembler dropTopOfFPU.
+	self 
+		assert: (assembler bytes)
+		equals: (#[221 216])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testDropTos__1 [
+	
+	assembler perform: #dropTos: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 196 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testEnsureRintegerBit [
+	
+	assembler perform: #ensureRintegerBit withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[12 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testEnsureSafeRintegerBit [
+	
+	assembler perform: #ensureSafeRintegerBit withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[12 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testExchangeRindirectWithT [
+	
+	assembler perform: #exchangeRindirectWithT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 135 8])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testIncA [
+	
+	assembler incA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 194])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testIncC [
+	
+	assembler incC.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 255 195])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testInitializeS [
+	
+	assembler perform: #initializeS withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 198])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testJumpIndirectA [
+	
+	assembler jumpIndirectA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 34])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testJumpToA [
+	
+	assembler jumpToA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 226])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testJumpToMindex__1 [
+	
+	assembler perform: #jumpToMindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 35])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testJumpToS [
+	
+	assembler jumpToS.
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 230])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLabeledIntegerBitTestOfA [
+	
+	assembler labeledIntegerBitTestOfA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[246 194 1 116 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledIntegerBitTestOfR [
+	
+	assembler perform: #labeledIntegerBitTestOfR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[168 1 116 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledIntegerBitTestOfT [
+	
+	assembler perform: #labeledIntegerBitTestOfT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[246 193 1 116 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledIntegerNativizationOfA [
+	
+	assembler perform: #labeledIntegerNativizationOfA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 250 115 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledIntegerNativizationOfR [
+	
+	assembler perform: #labeledIntegerNativizationOfR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 248 115 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledIntegerNativizationOfT [
+	
+	assembler perform: #labeledIntegerNativizationOfT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 249 115 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLabeledNonIntegerBitTestOfR [
+	
+	assembler perform: #labeledNonIntegerBitTestOfR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[168 1 117 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLeadingRzeroCount [
+	
+	assembler perform: #leadingRzeroCount withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[243 72 15 189 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__1 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 18])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__2 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 82 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__3 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 82 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__4 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 82 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__5 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 82 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithAindex__6 [
+	
+	assembler perform: #loadAwithAindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 82 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__1 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 23])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__2 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 87 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__3 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 87 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__4 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 87 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__5 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 87 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithEindex__6 [
+	
+	assembler perform: #loadAwithEindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 87 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__3 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__4 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__5 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__6 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m10 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 168])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m11 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 160])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m12 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 152])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m13 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 144])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m17 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-17).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 149 112 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m18 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 149 104 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m2 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m20 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-20).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 149 88 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m3 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m4 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 216])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m5 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m6 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m7 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m8 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 184])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithFPindex__m9 [
+	
+	assembler perform: #loadAwithFPindex: withArguments: #(-9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 85 176])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadAwithFalse [
+	
+	assembler loadAwithFalse.
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 242])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithLiteral__1405006117752879898543142606244511569936384000000000 [
+	
+	assembler perform: #loadAwithLiteral: withArguments: #(1405006117752879898543142606244511569936384000000000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 83 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithNil [
+	
+	assembler perform: #loadAwithNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 226])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithR [
+	
+	assembler perform: #loadAwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 194])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithRoffsetAtA [
+	
+	assembler perform: #loadAwithRoffsetAtA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 20 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithS [
+	
+	assembler perform: #loadAwithS withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 242])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__1 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 22])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__16 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 86 120])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__2 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 86 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__3 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 86 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__4 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 86 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSindex__5 [
+	
+	assembler perform: #loadAwithSindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 86 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__0 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 3 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__10 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 21 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__100 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(100).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 201 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1000 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 209 7 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1023 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1023).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 7 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1024 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1024).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 8 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1048575 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1048575).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 31 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1114112 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1114112).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 0 34 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__12 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 25 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__12288 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(12288).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 96 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__123 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(123).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 247 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__124 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(124).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 249 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__125 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(125).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 251 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__127 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(127).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__128 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(128).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__13 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 27 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__14 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 29 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__15 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 31 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__16 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 33 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__160 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(160).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 65 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__162 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(162).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 69 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__16273 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(16273).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 35 127 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__16383 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(16383).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 127 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__16384 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(16384).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 128 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__1664525 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(1664525).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 27 204 50 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__16777215 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(16777215).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 255 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__192 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(192).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 129 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__2 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 5 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__2047 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(2047).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 15 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__2048 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(2048).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 16 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__216 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(216).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 177 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__224 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(224).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 193 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__240 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(240).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 225 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__248 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(248).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 241 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__251 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(251).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 247 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__255 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(255).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__256 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(256).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 2 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__268435455 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(268435455).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 255 31])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__3 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 7 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__30000 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(30000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 97 234 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__31 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(31).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 63 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__32 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(32).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 65 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__32752 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(32752).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 225 255 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__32767 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(32767).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__32768 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(32768).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 0 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__34 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(34).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 69 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__35 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(35).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 71 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__36 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(36).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 73 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__39 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(39).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 79 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__4 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 9 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__41 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(41).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 83 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__42 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(42).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 85 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__4294967295 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(4294967295).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 186 255 255 255 255 1 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__4294967296 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(4294967296).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 186 1 0 0 0 2 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__43 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(43).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 87 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__45 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(45).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 91 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__4503599627370496 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(4503599627370496).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 186 1 0 0 0 0 0 32 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__46 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(46).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 93 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__48 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(48).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 97 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__49152 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(49152).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 128 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__5 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 11 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__50 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(50).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 101 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__5000 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(5000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 17 39 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__54 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(54).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 109 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__54625 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(54625).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 195 170 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__55 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(55).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 111 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__55296 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(55296).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 176 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__56320 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(56320).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 184 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__57 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(57).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 115 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__57344 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(57344).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 192 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__58 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(58).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 117 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__59 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(59).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 119 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__6 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 13 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__60 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(60).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 121 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__62 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(62).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 125 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__63 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(63).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 127 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__64 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(64).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 129 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__65535 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(65535).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__65536 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(65536).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 0 2 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__7 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 15 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__75 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(75).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 151 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__8 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 17 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__8192 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(8192).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 1 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__8204 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(8204).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 25 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__8239 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(8239).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 95 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__8287 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(8287).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 191 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__87 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(87).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 175 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__9 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 19 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__90 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(90).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 181 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__9007199254740992 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(9007199254740992).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 186 1 0 0 0 0 0 64 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__91 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(91).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 183 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__92 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(92).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 185 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__93 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(93).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 187 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__94 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(94).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 189 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__95 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(95).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 191 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__96 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(96).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 193 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__m1 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(-1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 255 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__m1023 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(-1023).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 3 248 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadAwithSmallInteger__m2 [
+	
+	assembler perform: #loadAwithSmallInteger: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 194 253 255 255 255])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadAwithT [
+	
+	assembler loadAwithT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 202])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadAwithTrue [
+	
+	assembler loadAwithTrue.
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 234])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadEwithAddressOfRatA [
+	
+	assembler perform: #loadEwithAddressOfRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 141 124 208 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadEwithNil [
+	
+	assembler perform: #loadEwithNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 231])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadEwithR [
+	
+	assembler perform: #loadEwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 199])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadFPwithR [
+	
+	assembler perform: #loadFPwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 197])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadFPwithSP [
+	
+	assembler loadFPwithSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 229])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadLargeX0withRindirect [
+	
+	assembler perform: #loadLargeX0withRindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 110 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadLargeX1withAindirect [
+	
+	assembler perform: #loadLargeX1withAindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 110 10])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadLongMwithIPoffset__m34 [
+	
+	assembler perform: #loadLongMwithIPoffset: withArguments: #(-34).
+	self 
+		assert: (assembler bytes)
+		equals: (#[139 29 216 255 255 255])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadLongRWithRAtOffsetA [
+	
+	assembler loadLongRWithRAtOffsetA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[139 4 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadLongRwithRatOffsetA [
+	
+	assembler perform: #loadLongRwithRatOffsetA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[139 4 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadLongSwithRindex__0 [
+	
+	assembler perform: #loadLongSwithRindex: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[139 112 252])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMXCSRfromA [
+	
+	assembler perform: #loadMXCSRfromA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[15 174 18])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithA [
+	
+	assembler perform: #loadMwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 211])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithMindex__2 [
+	
+	assembler perform: #loadMwithMindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 91 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithMindex__4 [
+	
+	assembler perform: #loadMwithMindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 91 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithRindex__1 [
+	
+	assembler perform: #loadMwithRindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__10 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 72])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__12 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 88])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__14 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 104])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__15 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 112])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__2 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__4 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__6 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadMwithTindex__8 [
+	
+	assembler perform: #loadMwithTindex: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 89 56])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadRConvertingDoubleRindirect [
+	
+	assembler loadRConvertingDoubleRindirect.
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 72 15 44 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRconvertingDoublePointedByR [
+	
+	assembler perform: #loadRconvertingDoublePointedByR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 72 15 44 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithA [
+	
+	assembler perform: #loadRwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithArgPointer [
+	
+	assembler perform: #loadRwithArgPointer withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 141 69 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithE [
+	
+	assembler perform: #loadRwithE withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__1 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 7])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__2 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__3 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__4 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__5 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__6 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithEindex__7 [
+	
+	assembler perform: #loadRwithEindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 71 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFP [
+	
+	assembler perform: #loadRwithFP withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__1 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__3 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__4 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__5 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__6 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__7 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__8 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 56])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__9 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 64])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m10 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 168])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m11 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 160])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m12 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 152])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m13 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 144])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m14 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 136])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m15 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 128])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m16 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 120 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m17 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-17).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 112 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m18 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 104 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m19 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-19).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 96 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m2 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m20 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-20).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 88 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m21 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-21).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 133 80 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m3 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m4 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 216])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m5 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m6 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m7 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m8 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 184])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFPindex__m9 [
+	
+	assembler perform: #loadRwithFPindex: withArguments: #(-9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 69 176])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithFalse [
+	
+	assembler perform: #loadRwithFalse withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 240])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithImmediate__0 [
+	
+	assembler perform: #loadRwithImmediate: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 0 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithM [
+	
+	assembler perform: #loadRwithM withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 216])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithMindex__2 [
+	
+	assembler perform: #loadRwithMindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 67 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithNil [
+	
+	assembler perform: #loadRwithNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRatA [
+	
+	assembler perform: #loadRwithRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 68 208 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRatOffsetA [
+	
+	assembler perform: #loadRwithRatOffsetA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 4 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__1 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__2 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__3 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__4 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__5 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__6 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithRindex__7 [
+	
+	assembler perform: #loadRwithRindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 64 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithS [
+	
+	assembler perform: #loadRwithS withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 240])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadRwithSP [
+	
+	assembler loadRwithSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSPindex__2 [
+	
+	assembler perform: #loadRwithSPindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 68 36 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSPindex__3 [
+	
+	assembler perform: #loadRwithSPindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 68 36 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSPindex__4 [
+	
+	assembler perform: #loadRwithSPindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 68 36 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__1 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 6])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__10 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 72])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__11 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 80])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__12 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 88])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__13 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 96])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__14 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 104])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__15 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 112])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__16 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 120])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__17 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(17).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 134 128 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__18 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 134 136 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__19 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(19).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 134 144 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__2 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__3 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__4 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__5 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__6 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__7 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__8 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 56])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSindex__9 [
+	
+	assembler perform: #loadRwithSindex: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 70 64])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__0 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 3 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__10 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 21 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__100 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(100).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 201 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 209 7 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__10000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(10000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 33 78 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1000000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1000000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 129 132 30 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1024 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1024).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 8 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1075 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1075).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 103 8 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__119886 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(119886).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 157 168 3 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__12 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 25 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__126 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(126).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 253 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__127 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(127).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 255 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__128 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(128).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__13 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 27 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__131072 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(131072).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 0 4 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__13131 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(13131).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 151 102 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__14 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 29 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__140000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(140000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 193 69 4 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__15 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 31 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__159 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(159).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 63 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__16 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 33 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__160 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(160).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 65 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__16384 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(16384).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 128 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__1664525 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(1664525).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 27 204 50 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__16777216 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(16777216).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 0 0 2])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__18 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 37 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__192 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(192).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 129 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__2 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 5 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__20 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(20).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 41 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__21 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(21).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 43 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__22 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(22).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 45 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__23 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(23).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 47 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__24 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(24).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 49 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__248 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(248).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 241 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__25 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(25).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 51 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__253 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(253).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 251 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__255 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(255).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 255 1 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__256 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(256).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 2 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__26 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(26).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 53 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__27 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(27).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 55 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__3 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 7 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__3000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(3000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 113 23 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__309 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(309).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 107 2 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__31 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(31).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 63 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__32 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(32).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 65 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__32767 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(32767).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 255 255 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__32768 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(32768).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 0 1 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__4 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 9 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__4000 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(4000).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 65 31 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__4096 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(4096).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 32 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__42 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(42).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 85 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__4294967296 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(4294967296).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 184 1 0 0 0 2 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__48 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(48).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 97 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__5 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 11 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__50 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(50).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 101 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__5381 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(5381).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 11 42 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__54 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(54).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 109 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__55 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(55).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 111 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__6 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 13 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__64 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(64).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 129 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__7 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 15 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 17 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8192 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8192).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8194 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8194).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 5 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8195 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8195).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 7 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8197 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8197).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 11 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8211 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8211).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 39 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8212 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8212).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 41 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8216 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8216).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 49 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8217 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8217).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 51 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8220 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8220).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 57 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8221 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8221).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 59 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8226 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8226).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 69 64 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8592 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8592).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 33 67 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8593 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8593).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 35 67 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8594 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8594).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 37 67 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8595 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8595).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 39 67 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8804 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8804).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 201 68 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8805 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8805).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 203 68 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8853 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8853).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 43 69 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__8855 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(8855).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 47 69 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__9 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 19 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m1 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 255 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m10 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 237 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m12 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 233 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m14 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 229 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m15 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 227 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m16 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 225 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m18 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 221 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m2 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 253 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m20 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-20).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 217 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m24 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-24).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 209 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m3 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 251 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m32 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-32).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 193 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m4096 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-4096).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 1 224 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m5 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 247 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m6 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 245 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m8 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 192 241 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithSmallInteger__m9007199254740992 [
+	
+	assembler perform: #loadRwithSmallInteger: withArguments: #(-9007199254740992).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 184 1 0 0 0 0 0 192 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithT [
+	
+	assembler perform: #loadRwithT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 200])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadRwithTIBatIndexR [
+	
+	assembler loadRwithTIBatIndexR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[101 72 139 4 197 0 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithThreadVariableAtIndexR [
+	
+	assembler perform: #loadRwithThreadVariableAtIndexR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[101 72 139 4 197 128 20 0 0])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadRwithTos [
+	
+	assembler loadRwithTos.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 4 36])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithTrue [
+	
+	assembler perform: #loadRwithTrue withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadRwithX0 [
+	
+	assembler perform: #loadRwithX0 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 126 192])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadSPwithFP [
+	
+	assembler loadSPwithFP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 236])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadSPwithT [
+	
+	assembler loadSPwithT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 204])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadSwithA [
+	
+	assembler loadSwithA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 214])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadSwithAddressOfSatA [
+	
+	assembler perform: #loadSwithAddressOfSatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 141 116 214 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadSwithNil [
+	
+	assembler perform: #loadSwithNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[76 137 230])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadSwithRindex__3 [
+	
+	assembler perform: #loadSwithRindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 112 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadSwithRindex__4 [
+	
+	assembler perform: #loadSwithRindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 112 24])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testLoadSwithT [
+	
+	assembler loadSwithT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 206])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithA [
+	
+	assembler perform: #loadTwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 209])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithAindex__3 [
+	
+	assembler perform: #loadTwithAindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 74 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithEindex__1 [
+	
+	assembler perform: #loadTwithEindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 15])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithEindex__2 [
+	
+	assembler perform: #loadTwithEindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 79 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithEindex__3 [
+	
+	assembler perform: #loadTwithEindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 79 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithEindex__4 [
+	
+	assembler perform: #loadTwithEindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 79 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithFPindex__3 [
+	
+	assembler perform: #loadTwithFPindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 77 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithFPindex__4 [
+	
+	assembler perform: #loadTwithFPindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 77 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithFPindex__5 [
+	
+	assembler perform: #loadTwithFPindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 77 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithFPindex__6 [
+	
+	assembler perform: #loadTwithFPindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 77 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithImmediate__0 [
+	
+	assembler perform: #loadTwithImmediate: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 199 193 0 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithR [
+	
+	assembler perform: #loadTwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 193])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadTwithTindex__1 [
+	
+	assembler perform: #loadTwithTindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 9])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadX0withRasDouble [
+	
+	assembler perform: #loadX0withRasDouble withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 72 15 42 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadX1roundingX0 [
+	
+	assembler perform: #loadX1roundingX0 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 15 58 11 200 3])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadZeroExtendByteRwithRatA [
+	
+	assembler perform: #loadZeroExtendByteRwithRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 15 182 68 16 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadZeroExtendByteRwithSPatA [
+	
+	assembler perform: #loadZeroExtendByteRwithSPatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 15 182 68 20 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadZeroExtendLongRwithRatA [
+	
+	assembler perform: #loadZeroExtendLongRwithRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[139 68 144 252])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLoadZeroExtendShortRwithRoffset__m8 [
+	
+	assembler perform: #loadZeroExtendShortRwithRoffset: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 15 183 64 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testLock [
+	
+	assembler perform: #lock withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[240])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testMoveTslots [
+	
+	assembler perform: #moveTslots withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[243 72 165])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testMultiplyDoubleX0byX1 [
+	
+	assembler perform: #multiplyDoubleX0byX1 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 89 193])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testMultiplyRbyA [
+	
+	assembler perform: #multiplyRbyA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 247 234])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testOrRwithA [
+	
+	assembler perform: #orRwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 9 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopA [
+	
+	assembler perform: #popA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[90])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPopB [
+	
+	assembler popB.
+	self 
+		assert: (assembler bytes)
+		equals: (#[91])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopE [
+	
+	assembler perform: #popE withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[95])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopFP [
+	
+	assembler perform: #popFP withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[93])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopFalse [
+	
+	assembler perform: #popFalse withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 94])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopG [
+	
+	assembler perform: #popG withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 95])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopM [
+	
+	assembler perform: #popM withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[91])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopNil [
+	
+	assembler perform: #popNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 92])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopR [
+	
+	assembler perform: #popR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[88])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopS [
+	
+	assembler perform: #popS withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[94])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPopSP [
+	
+	assembler popSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[92])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopSPindirect [
+	
+	assembler perform: #popSPindirect withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[143 4 36])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPopT [
+	
+	assembler popT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[89])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPopTrue [
+	
+	assembler perform: #popTrue withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 93])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushA [
+	
+	assembler perform: #pushA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[82])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPushB [
+	
+	assembler pushB.
+	self 
+		assert: (assembler bytes)
+		equals: (#[83])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushE [
+	
+	assembler perform: #pushE withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[87])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPushFP [
+	
+	assembler pushFP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[85])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushFalse [
+	
+	assembler perform: #pushFalse withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 86])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushG [
+	
+	assembler perform: #pushG withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 87])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushImmediate__0 [
+	
+	assembler perform: #pushImmediate: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[106 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushIndirectR [
+	
+	assembler perform: #pushIndirectR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[255 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushM [
+	
+	assembler perform: #pushM withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[83])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushNil [
+	
+	assembler perform: #pushNil withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 84])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushR [
+	
+	assembler perform: #pushR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[80])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushS [
+	
+	assembler perform: #pushS withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[86])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testPushSP [
+	
+	assembler pushSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[84])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushSmallInteger__0 [
+	
+	assembler perform: #pushSmallInteger: withArguments: #(0).
+	self 
+		assert: (assembler bytes)
+		equals: (#[106 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushSmallInteger__1 [
+	
+	assembler perform: #pushSmallInteger: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[106 3])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushSmallInteger__2 [
+	
+	assembler perform: #pushSmallInteger: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[106 5])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushSmallInteger__3 [
+	
+	assembler perform: #pushSmallInteger: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[106 7])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushT [
+	
+	assembler perform: #pushT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[81])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testPushTrue [
+	
+	assembler perform: #pushTrue withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[65 85])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testReadFPUStatusOnA [
+	
+	assembler readFPUStatusOnA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[155 221 58])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReserveStackSlots__13 [
+	
+	assembler perform: #reserveStackSlots: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 236 104])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReserveStackSlots__2 [
+	
+	assembler perform: #reserveStackSlots: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 236 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReserveStackSlots__3 [
+	
+	assembler perform: #reserveStackSlots: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 236 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReserveStackSlots__4 [
+	
+	assembler perform: #reserveStackSlots: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 236 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReserveStackSlots__5 [
+	
+	assembler perform: #reserveStackSlots: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 236 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testRestoreCallerEnvironment [
+	
+	assembler perform: #restoreCallerEnvironment withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 125 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testRestoreCallerFrame [
+	
+	assembler perform: #restoreCallerFrame withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 236 93])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testRestoreCallerM [
+	
+	assembler perform: #restoreCallerM withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 93 240])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testRestoreCallerSelf [
+	
+	assembler perform: #restoreCallerSelf withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 139 117 248])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testRestoreRSmallInteger [
+	
+	assembler restoreRSmallInteger.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 208])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testRestoreRsmallInteger [
+	
+	assembler restoreRsmallInteger.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testReturn [
+	
+	assembler perform: #return withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[195])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSaveCallerFrame [
+	
+	assembler perform: #saveCallerFrame withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[85 72 137 229])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testShiftLeftRwithT [
+	
+	assembler perform: #shiftLeftRwithT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 211 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testShiftRightRwithT [
+	
+	assembler perform: #shiftRightRwithT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 211 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testShiftRleft__1 [
+	
+	assembler perform: #shiftRleft: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 209 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSqrtDoubleX0 [
+	
+	assembler perform: #sqrtDoubleX0 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 81 192])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreAinSPatT [
+	
+	assembler storeAinSPatT.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 84 204 248])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreAinThreadVariableAtIndexR [
+	
+	assembler storeAinThreadVariableAtIndexR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[101 72 137 20 197 128 20 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreAinTindex__1 [
+	
+	assembler perform: #storeAinTindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 17])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreAinTindex__2 [
+	
+	assembler perform: #storeAinTindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 81 8])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreArgumentsInStack [
+	
+	assembler storeArgumentsInStack.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 77 16 72 137 85 24 76 137 69 32 76 137 77 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreByteTinRatA [
+	
+	assembler perform: #storeByteTinRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[136 76 16 255])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreDoubleResultInRindirect [
+	
+	assembler storeDoubleResultInRindirect.
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 126 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreEinRindex__3 [
+	
+	assembler perform: #storeEinRindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 120 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreEinRindex__4 [
+	
+	assembler perform: #storeEinRindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 120 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreEinRindex__5 [
+	
+	assembler perform: #storeEinRindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 120 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreLargeX0inA [
+	
+	assembler perform: #storeLargeX0inA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 126 2])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreLargeX0inR [
+	
+	assembler storeLargeX0inR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 126 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreLargeX0inT [
+	
+	assembler perform: #storeLargeX0inT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 72 15 126 1])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreLongTInRAtA [
+	
+	assembler storeLongTInRAtA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[137 76 144 252])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreLongTinRatA [
+	
+	assembler perform: #storeLongTinRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[137 76 144 252])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreLongTinRatOffsetA [
+	
+	assembler perform: #storeLongTinRatOffsetA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[137 12 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreMXCSRintoA [
+	
+	assembler perform: #storeMXCSRintoA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[15 174 26])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinAindex__2 [
+	
+	assembler perform: #storeRinAindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 66 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinEindex__1 [
+	
+	assembler perform: #storeRinEindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 7])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinEindex__2 [
+	
+	assembler perform: #storeRinEindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 71 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinEindex__3 [
+	
+	assembler perform: #storeRinEindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 71 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinEindex__6 [
+	
+	assembler perform: #storeRinEindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 71 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m10 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 168])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m11 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 160])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m12 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 152])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m13 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 144])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m14 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 136])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m15 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 128])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m16 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 133 120 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m17 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-17).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 133 112 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m18 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 133 104 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m19 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-19).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 133 96 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m2 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 232])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m20 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-20).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 133 88 255 255 255])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m3 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 224])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m4 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 216])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m5 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m6 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 200])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m7 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 192])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m8 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 184])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinFPindex__m9 [
+	
+	assembler perform: #storeRinFPindex: withArguments: #(-9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 69 176])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__1 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 6])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__10 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(10).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 72])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__11 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(11).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 80])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__12 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(12).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 88])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__13 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(13).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 96])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__14 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(14).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 104])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__15 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(15).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 112])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__16 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(16).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 120])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__17 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(17).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 134 128 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__18 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(18).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 134 136 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__19 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(19).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 134 144 0 0 0])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__2 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__3 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__4 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__5 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__6 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__7 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__8 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 56])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinSindex__9 [
+	
+	assembler perform: #storeRinSindex: withArguments: #(9).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 70 64])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinTindex__1 [
+	
+	assembler perform: #storeRinTindex: withArguments: #(1).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinTindex__2 [
+	
+	assembler perform: #storeRinTindex: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 65 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinTindex__3 [
+	
+	assembler perform: #storeRinTindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 65 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinTindex__4 [
+	
+	assembler perform: #storeRinTindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 65 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreRinTindex__5 [
+	
+	assembler perform: #storeRinTindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 65 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreShortAinRoffset__m8 [
+	
+	assembler perform: #storeShortAinRoffset: withArguments: #(-8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 137 80 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreShortTinRatOffsetA [
+	
+	assembler perform: #storeShortTinRatOffsetA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[102 137 12 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreSinRindex__3 [
+	
+	assembler perform: #storeSinRindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 112 16])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreTIBwithAatIndexR [
+	
+	assembler storeTIBwithAatIndexR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[101 72 137 20 197 0 0 0 0])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testStoreTInRAtA [
+	
+	assembler storeTInRAtA.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 76 208 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRatA [
+	
+	assembler perform: #storeTinRatA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 76 208 248])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRatOffsetA [
+	
+	assembler perform: #storeTinRatOffsetA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 12 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRindex__3 [
+	
+	assembler perform: #storeTinRindex: withArguments: #(3).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 72 16])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRindex__4 [
+	
+	assembler perform: #storeTinRindex: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 72 24])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRindex__5 [
+	
+	assembler perform: #storeTinRindex: withArguments: #(5).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 72 32])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRindex__6 [
+	
+	assembler perform: #storeTinRindex: withArguments: #(6).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 72 40])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testStoreTinRindex__7 [
+	
+	assembler perform: #storeTinRindex: withArguments: #(7).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 137 72 48])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubAfromR [
+	
+	assembler perform: #subAfromR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 41 208])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubAfromT [
+	
+	assembler perform: #subAfromT withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 41 209])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubDoubleX1fromX0 [
+	
+	assembler perform: #subDoubleX1fromX0 withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[242 15 92 193])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubFromRconstant__2 [
+	
+	assembler perform: #subFromRconstant: withArguments: #(2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 232 2])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubFromRconstant__4 [
+	
+	assembler perform: #subFromRconstant: withArguments: #(4).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 232 4])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubFromRconstant__8 [
+	
+	assembler perform: #subFromRconstant: withArguments: #(8).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 232 8])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testSubFromRconstant__m2 [
+	
+	assembler perform: #subFromRconstant: withArguments: #(-2).
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 131 232 254])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testSubTfromR [
+	
+	assembler subTfromR.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 41 200])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testSubTslotsToSP [
+	
+	assembler subTslotsToSP.
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 247 217 72 141 36 204 72 247 217])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testTestAintegerBit [
+	
+	assembler testAintegerBit.
+	self 
+		assert: (assembler bytes)
+		equals: (#[246 194 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testTestRintegerBit [
+	
+	assembler perform: #testRintegerBit withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[168 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testTestRwithR [
+	
+	assembler perform: #testRwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 133 192])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testTestTIntegerBit [
+	
+	assembler testTIntegerBit.
+	self 
+		assert: (assembler bytes)
+		equals: (#[246 193 1])
+	
+]
+
+{ #category : #'tests - generated' }
+JITAssemblerAMD64Test >> testTestTintegerBit [
+	
+	assembler testTintegerBit.
+	self 
+		assert: (assembler bytes)
+		equals: (#[246 193 1])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testWriteTslots [
+	
+	assembler perform: #writeTslots withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[243 72 171])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testXorAwithR [
+	
+	assembler perform: #xorAwithR withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 49 194])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testXorFPwithFP [
+	
+	assembler perform: #xorFPwithFP withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 49 237])
+	
+]
+
+{ #category : #'tests - generated 2' }
+JITAssemblerAMD64Test >> testXorRwithA [
+	
+	assembler perform: #xorRwithA withArguments: #().
+	self 
+		assert: (assembler bytes)
+		equals: (#[72 49 208])
+	
+]

--- a/bootstrap/src/Powerlang-Tests/MessageCollector.class.st
+++ b/bootstrap/src/Powerlang-Tests/MessageCollector.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #MessageCollector,
+	#superclass : #Object,
+	#instVars : [
+		'subject'
+	],
+	#classVars : [
+		'Messages'
+	],
+	#category : #'Powerlang-Tests'
+}
+
+{ #category : #'instance creation' }
+MessageCollector class >> for: anObject [
+	^ self new 
+		subject: anObject;
+		yourself
+
+]
+
+{ #category : #initialization }
+MessageCollector class >> initialize [
+	"Invoked at system start or when the class is dynamically loaded."
+
+	"  please change as required (and remove this comment)"
+
+	Messages := Set new
+
+]
+
+{ #category : #accessing }
+MessageCollector class >> messages [
+	^ Messages
+
+]
+
+{ #category : #hooks }
+MessageCollector >> doesNotUnderstand: aMessage [
+	(aMessage arguments allSatisfy: [:e | e isInteger ]) ifTrue: [ 
+		(Messages contains: [:e | e selector = aMessage selector and:[e arguments = aMessage arguments]]) ifFalse: [ 
+			Messages add: aMessage.
+		].
+	].
+	^ aMessage sendTo: subject
+
+]
+
+{ #category : #accessing }
+MessageCollector >> subject [
+	^ subject
+]
+
+{ #category : #accessing }
+MessageCollector >> subject:anObject [
+	subject := anObject.
+
+]

--- a/bootstrap/src/Powerlang-Tests/SExpressionTest.class.st
+++ b/bootstrap/src/Powerlang-Tests/SExpressionTest.class.st
@@ -21,8 +21,8 @@ SExpressionTest class >> supportMethodsUsing: anEnvironment [
 	^ self supportMethods collect: [ :method | 
 		  | copy |
 		  copy := method copy
-			          classBinding: Object;
-			          yourself.
+					  classBinding: Object;
+					  yourself.
 		  self nativize: copy using: anEnvironment.
 		  copy ]
 ]

--- a/bootstrap/src/Powerlang-Tests/TemplateAssemblerAMD64Test.class.st
+++ b/bootstrap/src/Powerlang-Tests/TemplateAssemblerAMD64Test.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #TemplateAssemblerAMD64Test,
+	#superclass : #JITAssemblerAMD64Test,
+	#category : #'Powerlang-Tests-Assembler-JIT'
+}
+
+{ #category : #running }
+TemplateAssemblerAMD64Test >> setUp [
+	super setUp.
+	assembler := TemplateAssemblerAMD64 new wordSize: 8.
+	
+]


### PR DESCRIPTION
This commit adds tests for assembler (code generator). These tests were automatically generated based 
on what the code currently generates, so they're garbage-in-garbage-out test. However, they already found
a bug in template assembler and proved to be *very* useful when refactoring the assembler classes. 
