### PR TITLE
Method sources

### DIFF
--- a/src/Powerlang-Core/PowertalkRingImage.class.st
+++ b/src/Powerlang-Core/PowertalkRingImage.class.st
@@ -231,24 +231,26 @@ PowertalkRingImage >> transferCharacter: aCharacter [
 
 { #category : #initialization }
 PowertalkRingImage >> transferMethod: anSCompiledMethod in: species [
-	| size classname transferred astcodes selector format literal tliteral |
-	(identityMap includesKey: anSCompiledMethod)
-		ifTrue: [ self ASSERT: false ].
+
+	| size classname transferred astcodes selector format literal tliteral source |
+	(identityMap includesKey: anSCompiledMethod) ifTrue: [ 
+		self ASSERT: false ].
 	size := anSCompiledMethod size.
 	classname := anSCompiledMethod isCallback
-		ifTrue: [ 'CallbackMethod' ]
-		ifFalse: [ 'CompiledMethod' ].
+		             ifTrue: [ 'CallbackMethod' ]
+		             ifFalse: [ 'CompiledMethod' ].
 	transferred := self newSlots: classname sized: size.
 	identityMap at: anSCompiledMethod put: transferred.
 	astcodes := self transferLiteralDeep: anSCompiledMethod astcodes.
 	selector := self newSymbol: anSCompiledMethod selector.
 	format := self newInteger: anSCompiledMethod format.
+	source := self newString: anSCompiledMethod source.
 	transferred
 		astcodes: astcodes;
 		class: species;
 		selector: selector;
 		format: format;
-		source: nilObj.
+		source: source.
 	1 to: size do: [ :i | 
 		literal := anSCompiledMethod at: i.
 		tliteral := self transferLiteralDeep: literal.


### PR DESCRIPTION
Make sources available in the virtual runtime.

I'm implementing the Webside API (in the host Pharo image for the moment), in order to enable access to the "inner" image/runtime from (very) outside (to be able to browse/edit code, evaluate, inspect and debug within the inner smalltalk).
As the first step (code endpoints), I detected that compiled methods didn't have their source (they were explicitly set to nil), so I extended the "transference" of methods from specs/outer smalltalk to the inner one to set them with the corresponding source code.
Here is the Webside class browser working on inner smalltalk (just browsing for the moment; next step is enabling changes, evaluations (need to load the compiler in the inner image), inspection and debugging.

![image](https://user-images.githubusercontent.com/43265642/171776172-6cb59662-39cb-4378-8847-ff1df3156ecb.png)
