### PR TITLE
Do not load UI by default when using `make`

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -1,3 +1,5 @@
+# Metacello group to load.
+GROUP ?= base
 
 all: pharo-ui bootstrap.image
 
@@ -7,7 +9,7 @@ pharo pharo-ui Pharo.image:
 bootstrap.image: pharo Pharo.image src
 	./pharo Pharo.image save bootstrap
 	./pharo $@ eval --save "(IceRepositoryCreator new location: '..' asFileReference; createRepository) register"
-	./pharo $@ metacello install tonel://./src BaselineOfPowerlang
+	./pharo $@ metacello install tonel://./src BaselineOfPowerlang --groups=$(GROUP)
 	./pharo $@ eval --save "SystemWindow closeTopWindow. GTPlayground openContents: 'README.md' asFileReference contents withSqueakLineEndings"
 	@echo ""
 	@echo "To open Pharo bootstrap image run:"

--- a/bootstrap/src/BaselineOfPowerlang/BaselineOfPowerlang.class.st
+++ b/bootstrap/src/BaselineOfPowerlang/BaselineOfPowerlang.class.st
@@ -25,10 +25,23 @@ BaselineOfPowerlang >> baseline: spec [
 			spec requires: 'PetitParser'
 		].
 		spec package: 'Powerlang-Tests'.
-		spec	package: 'Powerlang-TestsFailing'.
-		spec	package: 'Powerlang-UI' with:[
+		spec package: 'Powerlang-TestsFailing'.
+		spec package: 'Powerlang-UI' with:[
 			spec requires: 'Roassal3'
-		]
+		].
+
+		"base group: just core boostrapping code and tests"
+		spec group: 'base' with: #('Powerlang-Compatibility-Pharo'
+								   'Powerlang-Core'
+		                           'Powerlang-Tests'
+		                           'Powerlang-TestsFailing').
+
+		"devel group: base, tests and custom dev tools"
+		spec group: 'devel' with: #('base'
+		                            'Powerlang-UI').
+
+		"default group: loaded when group is not specified"
+		spec group: 'default' with: #('devel').
 	]
 ]
 


### PR DESCRIPTION
This PR introduces new 'base' and 'devel' Metacello groups.

The 'base' group (loaded by default by `make`) loads only
core bootstrap code and tests. The `devel` group (loaded by
default when no group is specified) loads the UI package in
addition. To use `make` to load `devel` group, use

    make GROUP=devel ...